### PR TITLE
Fix pulseaudio locking

### DIFF
--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -518,6 +518,7 @@ PaError PaPulseAudio_Initialize(
     (*hostApi)->info.defaultOutputDevice = paNoDevice;
 
     /* Connect to server */
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
     l_iRtn = pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
 
     if(l_iRtn < 0)
@@ -525,6 +526,7 @@ PaError PaPulseAudio_Initialize(
         PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
                                           "PaPulseAudio_Initialize: Can't connect to server");
         result = paNoError;
+        pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
         goto error;
     }
 
@@ -584,6 +586,7 @@ PaError PaPulseAudio_Initialize(
     }
 
     pa_operation_unref(l_ptrOperation);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     (*hostApi)->info.deviceCount = l_ptrPulseAudioHostApi->deviceCount;
 
@@ -685,7 +688,9 @@ static void Terminate(
         PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
     }
 
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
     pa_context_disconnect(l_ptrPulseAudioHostApi->context);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     PulseAudioFree(l_ptrPulseAudioHostApi);
 }


### PR DESCRIPTION
@illuusio I think you're right about wrapping the context calls with locks. thread-mainloop.h says:

> The added feature in the threaded main loop is that it spawns a new thread
> that runs the real main loop. This allows a synchronous application to use
> the asynchronous API without risking to stall the PulseAudio library.

And then goes on to discuss locking:

> Since the PulseAudio API doesn't allow concurrent accesses to objects,
> a locking scheme must be used to guarantee safe usage. The threaded main
> loop API provides such a scheme through the functions
> pa_threaded_mainloop_lock() and pa_threaded_mainloop_unlock().
> 
> The lock is recursive, so it's safe to use it multiple times from the same
> thread. Just make sure you call pa_threaded_mainloop_unlock() the same
> number of times you called pa_threaded_mainloop_lock().
> 
> The lock needs to be held whenever you call any PulseAudio function that
> uses an object associated with this main loop. Make sure you do not hold
> on to the lock more than necessary though, as the threaded main loop stops
> while the lock is held.

It also explictly says that the lock must be held when calling pa_threaded_mainloop_wait. So this means all the stuff in PaPulseAudio_Initialize _does_ need to happen while locked, therefore I've reinstated the locks that were removed in   207937b (actually I just hold the lock for the whole time we are doing pulse stuff). The only other place I could find making a pulse call without the lock held was Terminate.
