### PR TITLE
Fix blocking API glitches

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ PALIB = libportaudio.la
 PAINC = include/portaudio.h
 
 PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaPulseaudio|PaAlsa|PaAsio|PaOSS)_.*" \
+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaPulseAudio|PaAlsa|PaAsio|PaOSS)_.*" \
 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 COMMON_OBJS = \

--- a/Makefile.in
+++ b/Makefile.in
@@ -44,7 +44,7 @@ PALIB = libportaudio.la
 PAINC = include/portaudio.h
 
 PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS)_.*" \
+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaPulseaudio|PaAlsa|PaAsio|PaOSS)_.*" \
 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 COMMON_OBJS = \
@@ -145,6 +145,7 @@ SRC_DIRS = \
 	src/hostapi/coreaudio \
 	src/hostapi/dsound \
 	src/hostapi/jack \
+	src/hostapi/pulseaudio \
 	src/hostapi/oss \
 	src/hostapi/wasapi \
 	src/hostapi/wdmks \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Portaudio-Pulseaudio -driver
-This is HostAPI Pulseaudio-driver for Portaudio. Pulseaudio in Common audio API for Linux today.
-  * Pulseaudio (http://www.freedesktop.org/wiki/Software/PulseAudio/)
+# Portaudio-PulseAudio -driver
+This is HostAPI PulseAudio-driver for Portaudio. PulseAudio in Common audio API for Linux today.
+  * PulseAudio (http://www.freedesktop.org/wiki/Software/PulseAudio/)
   * Official Portaudio (http://www.portaudio.com/)
 
 ## Little warning
-This is just for Linux and if you don't know what Pulseaudio or Portaudio is you don't need this.<br>
+This is just for Linux and if you don't know what PulseAudio or Portaudio is you don't need this.<br>
 **THIS IS NOT OFFICIAL PORTAUDIO REPOSITORY! IT IS: https://www.assembla.com/spaces/portaudio/subversion/source/HEAD/portaudio/trunk**<br>
-*I don't want any Pull Requests or bug reports other than Pulseaudio driver related.*
+*I don't want any Pull Requests or bug reports other than PulseAudio driver related.*
 
 ## Compiling
 You need
@@ -35,7 +35,7 @@ LD_CONFIG_PATH=/location/of/portaudio-pulseaudio/lib/.libs ./your-share-applicat
 *Again There is strong possibility that this driver won't work as you like. _You have been warned_*
 
 # Bugs
-I know many of them but I welcome bug reports or Pull Requests to fix them (**but only Portaudio-Pulseaudio-driver related**).<br>
+I know many of them but I welcome bug reports or Pull Requests to fix them (**but only Portaudio-PulseAudio-driver related**).<br>
 If you have Linux ALSA/Jack related Portaudio problem please refer: http://www.portaudio.com/contacts.html.
 
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# portaudio-pulseaudio
-Portaudio Pulseaudio plugin
+# Portaudio-Pulseaudio -driver
+This is HostAPI Pulseaudio-driver for Portaudio. Pulseaudio in Common audio API for Linux today.
+  * Pulseaudio (http://www.freedesktop.org/wiki/Software/PulseAudio/)
+  * Official Portaudio (http://www.portaudio.com/)
+
+## Little warning
+This is just for Linux and if you don't know what Pulseaudio or Portaudio is you don't need this.<br>
+**THIS IS NOT OFFICIAL PORTAUDIO REPOSITORY! IT IS: https://www.assembla.com/spaces/portaudio/subversion/source/HEAD/portaudio/trunk**<br>
+*I don't want any Pull Requests or bug reports other than Pulseaudio driver related.*
+
+## Compiling
+You need
+  * aclocal
+  * autoconf
+  * automake
+  * libtools
+  * make
+
+This should get this compile:
+
+1. aclocal
+2. libtoolize -f
+3. autoconf -f
+4. automake -f
+5. ./configure
+6. make
+
+There is also CMake version. But haven't got time to investigate it yet.
+
+## Using
+This is _Beta software_ and it will probably eat your dog's food but I'm using it like this:
+<pre>
+LD_CONFIG_PATH=/location/of/portaudio-pulseaudio/lib/.libs ./your-share-application
+</pre>
+*Again There is strong possibility that this driver won't work as you like. _You have been warned_*
+
+# Bugs
+I know many of them but I welcome bug reports or Pull Requests to fix them (**but only Portaudio-Pulseaudio-driver related**).<br>
+If you have Linux ALSA/Jack related Portaudio problem please refer: http://www.portaudio.com/contacts.html.
+
+

--- a/configure.in
+++ b/configure.in
@@ -136,7 +136,7 @@ if test "x$with_oss" != "xno"; then
         AC_CHECK_LIB(ossaudio, _oss_ioctl, have_libossaudio=yes, have_libossaudio=no)
     fi
 fi
-if [[ "x$with_jack" = "xyes" ] || [ "x$with_pulseaudio" = "xyes" ]]; then
+if [[ "x$with_jack" != "xno" ] || [ "x$with_pulseaudio" != "xno" ]]; then
     PKG_PROG_PKG_CONFIG
 fi
 have_jack=no

--- a/configure.in
+++ b/configure.in
@@ -143,9 +143,9 @@ have_jack=no
 if test "x$with_jack" != "xno"; then
     PKG_CHECK_MODULES(JACK, jack, have_jack=yes, have_jack=no)
 fi
-have_pulse=no
+have_pulseaudio=no
 if test "x$with_pulseaudio" != "xno"; then
-    PKG_CHECK_MODULES(PULSE, libpulse, have_pulse=yes, have_pulse=no)
+    PKG_CHECK_MODULES(PULSEAUDIO, libpulse, have_pulseaudio=yes, have_pulseaudio=no)
 fi
 
 
@@ -408,7 +408,7 @@ case "${host_os}" in
            AC_DEFINE(PA_USE_ALSA,1)
         fi
 
-        if [[ "$have_pulse" = "yes" ] || [ "$have_jack" = "yes" ]] ; then
+        if [[ "$have_pulseaudio" = "yes" ] || [ "$have_jack" = "yes" ]] ; then
            OTHER_OBJS="$OTHER_OBJS src/common/pa_ringbuffer.o"
         fi
 
@@ -420,9 +420,9 @@ case "${host_os}" in
            AC_DEFINE(PA_USE_JACK,1)
         fi
 
-        if [[ "$have_pulse" = "yes" ] && [ "$with_pulse" != "no" ]] ; then
-           DLL_LIBS="$DLL_LIBS $PULSE_LIBS"
-           CFLAGS="$CFLAGS $PULSE_CFLAGS"
+        if [[ "$have_pulseaudio" = "yes" ] && [ "$with_pulse" != "no" ]] ; then
+           DLL_LIBS="$DLL_LIBS $PULSEAUDIO_LIBS"
+           CFLAGS="$CFLAGS $PULSEAUDIO_CFLAGS"
            OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.o"
            OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.o"
            OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio.o"
@@ -527,7 +527,7 @@ case "$target_os" in
 	AC_MSG_RESULT([
   OSS ......................... $have_oss
   JACK ........................ $have_jack
-  PulseAudio .................. $have_pulse
+  PulseAudio .................. $have_pulseaudio
 ])
         ;;
 esac

--- a/configure.in
+++ b/configure.in
@@ -29,7 +29,7 @@ AC_ARG_WITH(jack,
             [with_jack=$withval])
 
 AC_ARG_WITH(pulseaudio,
-            AS_HELP_STRING([--with-pulseaudio], [Enable support for Pulseaudio @<:@autodetect@:>@]),
+            AS_HELP_STRING([--with-pulseaudio], [Enable support for PulseAudio @<:@autodetect@:>@]),
             [with_pulseaudio=$withval])
 
 AC_ARG_WITH(oss,
@@ -520,7 +520,7 @@ case "$target_os" in
 	AC_MSG_RESULT([
   OSS ......................... $have_oss
   JACK ........................ $have_jack
-  Pulseaudio .................. $have_pulse
+  PulseAudio .................. $have_pulse
 ])
         ;;
 esac

--- a/configure.in
+++ b/configure.in
@@ -28,6 +28,10 @@ AC_ARG_WITH(jack,
             AS_HELP_STRING([--with-jack], [Enable support for JACK @<:@autodetect@:>@]),
             [with_jack=$withval])
 
+AC_ARG_WITH(pulseaudio,
+            AS_HELP_STRING([--with-pulseaudio], [Enable support for Pulseaudio @<:@autodetect@:>@]),
+            [with_pulseaudio=$withval])
+
 AC_ARG_WITH(oss,
             AS_HELP_STRING([--with-oss], [Enable support for OSS @<:@autodetect@:>@]),
             [with_oss=$withval])
@@ -135,6 +139,10 @@ fi
 have_jack=no
 if test "x$with_jack" != "xno"; then
     PKG_CHECK_MODULES(JACK, jack, have_jack=yes, have_jack=no)
+fi
+have_pulse=no
+if test "x$with_pulseaudio" != "xno"; then
+    PKG_CHECK_MODULES(PULSE, libpulse, have_pulse=yes, have_pulse=no)
 fi
 
 
@@ -405,6 +413,16 @@ case "${host_os}" in
            AC_DEFINE(PA_USE_JACK,1)
         fi
 
+        if [[ "$have_pulse" = "yes" ] && [ "$with_pulse" != "no" ]] ; then
+           DLL_LIBS="$DLL_LIBS $PULSE_LIBS"
+           CFLAGS="$CFLAGS $PULSE_CFLAGS"
+           OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.o"
+           OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.o"
+           OTHER_OBJS="$OTHER_OBJS src/hostapi/pulseaudio/pa_hostapi_pulseaudio.o"
+           dnl INCLUDES="$INCLUDES pa_pulseaudio.h src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h"
+           AC_DEFINE(PA_USE_PULSEAUDIO,1)
+        fi
+
         if [[ "$with_oss" != "no" ]] ; then
            OTHER_OBJS="$OTHER_OBJS src/hostapi/oss/pa_unix_oss.o"
            if [[ "$have_libossaudio" = "yes" ]] ; then
@@ -502,6 +520,7 @@ case "$target_os" in
 	AC_MSG_RESULT([
   OSS ......................... $have_oss
   JACK ........................ $have_jack
+  Pulseaudio .................. $have_pulse
 ])
         ;;
 esac

--- a/configure.in
+++ b/configure.in
@@ -136,6 +136,9 @@ if test "x$with_oss" != "xno"; then
         AC_CHECK_LIB(ossaudio, _oss_ioctl, have_libossaudio=yes, have_libossaudio=no)
     fi
 fi
+if [[ "x$with_jack" = "xyes" ] || [ "x$with_pulseaudio" = "xyes" ]]; then
+    PKG_PROG_PKG_CONFIG
+fi
 have_jack=no
 if test "x$with_jack" != "xno"; then
     PKG_CHECK_MODULES(JACK, jack, have_jack=yes, have_jack=no)
@@ -405,10 +408,14 @@ case "${host_os}" in
            AC_DEFINE(PA_USE_ALSA,1)
         fi
 
+        if [[ "$have_pulse" = "yes" ] || [ "$have_jack" = "yes" ]] ; then
+           OTHER_OBJS="$OTHER_OBJS src/common/pa_ringbuffer.o"
+        fi
+
         if [[ "$have_jack" = "yes" ] && [ "$with_jack" != "no" ]] ; then
            DLL_LIBS="$DLL_LIBS $JACK_LIBS"
            CFLAGS="$CFLAGS $JACK_CFLAGS"
-           OTHER_OBJS="$OTHER_OBJS src/hostapi/jack/pa_jack.o src/common/pa_ringbuffer.o"
+           OTHER_OBJS="$OTHER_OBJS src/hostapi/jack/pa_jack.o"
            INCLUDES="$INCLUDES pa_jack.h"
            AC_DEFINE(PA_USE_JACK,1)
         fi

--- a/include/portaudio.h
+++ b/include/portaudio.h
@@ -270,7 +270,8 @@ typedef enum PaHostApiTypeId
     paWDMKS=11,
     paJACK=12,
     paWASAPI=13,
-    paAudioScienceHPI=14
+    paAudioScienceHPI=14,
+    paPulseaudio=15
 } PaHostApiTypeId;
 
 

--- a/include/portaudio.h
+++ b/include/portaudio.h
@@ -271,7 +271,7 @@ typedef enum PaHostApiTypeId
     paJACK=12,
     paWASAPI=13,
     paAudioScienceHPI=14,
-    paPulseaudio=15
+    paPulseAudio=15
 } PaHostApiTypeId;
 
 

--- a/src/common/pa_hostapi.h
+++ b/src/common/pa_hostapi.h
@@ -67,7 +67,7 @@ are defaulted to 1.
 #define PA_USE_SKELETON 1
 #endif 
 
-#if defined(PA_NO_ASIO) || defined(PA_NO_DS) || defined(PA_NO_WMME) || defined(PA_NO_WASAPI) || defined(PA_NO_WDMKS)
+#if defined(PA_NO_PULSEAUDIO) || defined(PA_NO_ASIO) || defined(PA_NO_DS) || defined(PA_NO_WMME) || defined(PA_NO_WASAPI) || defined(PA_NO_WDMKS)
 #error "Portaudio: PA_NO_<APINAME> is no longer supported, please remove definition and use PA_USE_<APINAME> instead"
 #endif
 
@@ -130,6 +130,13 @@ are defaulted to 1.
 #elif (PA_USE_JACK != 0) && (PA_USE_JACK != 1)
 #undef PA_USE_JACK
 #define PA_USE_JACK 1
+#endif 
+
+#ifndef PA_USE_PULSEAUDIO
+#define PA_USE_PULSEAUDIO 0
+#elif (PA_USE_PULSEAUDIO != 0) && (PA_USE_PULSEAUDIO != 1)
+#undef PA_USE_PULSEAUDIO
+#define PA_USE_PULSEAUDIO 1
 #endif 
 
 #ifndef PA_USE_SGI

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -139,7 +139,6 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
 
 fail:
     PulseaudioFree(ptr);
-    free(ptr);
     return NULL;
 }
 
@@ -161,6 +160,7 @@ void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr)
         pa_threaded_mainloop_free(ptr->mainloop);
     }
 
+    PaUtil_FreeMemory(ptr);
 }
 
 
@@ -543,7 +543,7 @@ error:
             PaUtil_DestroyAllocationGroup(l_ptrPulseaudioHostApi->allocations);
         }
 
-        PaUtil_FreeMemory(l_ptrPulseaudioHostApi);
+        PulseaudioFree(l_ptrPulseaudioHostApi);
     }
 
     return result;
@@ -563,8 +563,6 @@ static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
     pa_context_disconnect(l_ptrPulseaudioHostApi->context);
 
     PulseaudioFree(l_ptrPulseaudioHostApi);
-
-    PaUtil_FreeMemory(l_ptrPulseaudioHostApi);
 }
 
 
@@ -991,6 +989,7 @@ error:
     if(stream)
     {
         PaUtil_FreeMemory(stream);
+        PulseaudioFree(l_ptrPulseaudioHostApi);
     }
 
     return paNotInitialized;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -557,8 +557,6 @@ PaError PaPulseAudio_Initialize(
         }
     }
 
-    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
-
     memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00,
            sizeof(PaDeviceInfo) * 1024);
     for (i = 0; i < 1024; i++)
@@ -571,8 +569,6 @@ PaError PaPulseAudio_Initialize(
                                       PulseAudioSinkListCb,
                                       l_ptrPulseAudioHostApi);
 
-    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
-
     while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
     {
         pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
@@ -580,13 +576,10 @@ PaError PaPulseAudio_Initialize(
 
     pa_operation_unref(l_ptrOperation);
 
-    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
     l_ptrOperation =
         pa_context_get_source_info_list(l_ptrPulseAudioHostApi->context,
                                         PulseAudioSourceListCb,
                                         l_ptrPulseAudioHostApi);
-
-    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
     {

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -533,41 +533,28 @@ PaError PaPulseAudio_Initialize(
         goto error;
     }
 
-    while (1)
-    {
-        pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
+    l_iRtn = 0;
 
-        switch (l_ptrPulseAudioHostApi->state)
+    /* We should wait that PulseAudio server let us in or fails us */
+    while (!l_iRtn)
+    {
+        pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
+
+        switch (pa_context_get_state(l_ptrPulseAudioHostApi->context))
         {
             case PA_CONTEXT_READY:
+                l_iRtn = 1;
                 break;
-
             case PA_CONTEXT_TERMINATED:
             case PA_CONTEXT_FAILED:
                 goto error;
                 break;
             case PA_CONTEXT_UNCONNECTED:
-                break;
-
-
             case PA_CONTEXT_CONNECTING:
-                break;
-
             case PA_CONTEXT_AUTHORIZING:
-                break;
-
             case PA_CONTEXT_SETTING_NAME:
                 break;
         }
-
-        if (l_ptrPulseAudioHostApi->state == PA_CONTEXT_READY)
-        {
-            pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
-            break;
-        }
-
-        pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
-        usleep(100);
     }
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -491,6 +491,7 @@ PaError PaPulseAudio_Initialize(
     PaError result = paNoError;
     int i;
     int deviceCount;
+    int l_iRtn = 0;
     PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = NULL;
     PaDeviceInfo *deviceInfoArray = NULL;
 
@@ -508,7 +509,6 @@ PaError PaPulseAudio_Initialize(
 
     if (!l_ptrPulseAudioHostApi->allocations)
     {
-        PulseAudioFree(l_ptrPulseAudioHostApi);
         result = paInsufficientMemory;
         goto error;
     }
@@ -523,7 +523,15 @@ PaError PaPulseAudio_Initialize(
     (*hostApi)->info.defaultOutputDevice = paNoDevice;
 
     /* Connect to server */
-    pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
+    l_iRtn = pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
+
+    if(l_iRtn < 0)
+    {
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PaPulseAudio_Initialize: Can't connect to server");
+        result = paNoError;
+        goto error;
+    }
 
     while (1)
     {
@@ -680,6 +688,7 @@ PaError PaPulseAudio_Initialize(
         }
 
         PulseAudioFree(l_ptrPulseAudioHostApi);
+        l_ptrPulseAudioHostApi = NULL;
     }
 
     return result;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -518,6 +518,7 @@ PaError PaPulseAudio_Initialize(
     (*hostApi)->info.defaultOutputDevice = paNoDevice;
 
     /* Connect to server */
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
     l_iRtn = pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
 
     if(l_iRtn < 0)
@@ -525,6 +526,7 @@ PaError PaPulseAudio_Initialize(
         PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
                                           "PaPulseAudio_Initialize: Can't connect to server");
         result = paNoError;
+        pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
         goto error;
     }
 
@@ -584,6 +586,7 @@ PaError PaPulseAudio_Initialize(
     }
 
     pa_operation_unref(l_ptrOperation);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     (*hostApi)->info.deviceCount = l_ptrPulseAudioHostApi->deviceCount;
 
@@ -685,7 +688,9 @@ static void Terminate(
         PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
     }
 
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
     pa_context_disconnect(l_ptrPulseAudioHostApi->context);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     PulseAudioFree(l_ptrPulseAudioHostApi);
 }

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -73,6 +73,9 @@
 #define PULSEAUDIO_TIME_EVENT_USEC 50000
 #define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
 
+/* This is used to identify process name for Pulseaudio. */
+extern char *__progname;
+
 /* Pulseaudio specific functions */
 int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr)
 {
@@ -115,7 +118,7 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
     }
 
     memset(buf, 0x00, PATH_MAX + 20);
-    snprintf(buf, sizeof(buf), "Portaudio Pulseaudio HostApi");
+    snprintf(buf, sizeof(buf), "%s", __progname);
 
     ptr->context =
         pa_context_new(pa_threaded_mainloop_get_api(ptr->mainloop), buf);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -224,8 +224,8 @@ static void PulseAudioCheckContextStateCb(
 
 int _PulseAudioAddAudioDevice(
     PaPulseAudioHostApiRepresentation *hostapi,
-    const char *interfaceName,
-    const char *realName,
+    const char *PulseAudioSinkSourceName,
+    const char *PulseAudioSinkSourceNameDesc,
     int inputChannels,
     int outputChannels,
     double defaultLowInputLatency,
@@ -236,8 +236,8 @@ int _PulseAudioAddAudioDevice(
 )
 {
     /* These should be at leat 1 */
-    int l_iRealNameLen = strnlen(realName, 1024) + 1;
-    int l_iDeviceNameLen = strnlen(interfaceName, 1024) + 1;
+    int l_iRealNameLen = strnlen(PulseAudioSinkSourceNameDesc, 1024) + 1;
+    int l_iDeviceNameLen = strnlen(PulseAudioSinkSourceName, 1024) + 1;
     char *l_ptrName = NULL;
     char *l_strLocalName = NULL;
     
@@ -255,10 +255,10 @@ int _PulseAudioAddAudioDevice(
     }
 
     strncpy(hostapi->pulseaudioDeviceNames[hostapi->deviceCount],
-            realName, l_iRealNameLen);
+            PulseAudioSinkSourceNameDesc, l_iRealNameLen);
 
     strncpy(l_strLocalName,
-          interfaceName, (l_iDeviceNameLen - 1));
+          PulseAudioSinkSourceName, (l_iDeviceNameLen - 1));
 
     hostapi->deviceInfoArray[hostapi->deviceCount].name = l_strLocalName;
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -94,15 +94,21 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
 
     ptr = (PaPulseaudioHostApiRepresentation*)PaUtil_AllocateMemory(sizeof(PaPulseaudioHostApiRepresentation));
 
+    /* prt is NULL if runs out of memory or pointer to allocated memory */
     if (!ptr)
     {
-        return NULL;
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio can't alloc memory");
+	return NULL;
     }
+
+    /* Make sure we have NULL all struct first */
+    memset(ptr, 0x00, sizeof(PaPulseaudioHostApiRepresentation));
 
     ptr->mainloop = pa_threaded_mainloop_new();
 
     if (!ptr->mainloop)
     {
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio can't alloc mainloop");
         goto fail;
     }
 
@@ -114,6 +120,7 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
 
     if (!ptr->context)
     {
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio can't alloc context");
         goto fail;
     }
 
@@ -122,6 +129,7 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
 
     if (pa_threaded_mainloop_start(ptr->mainloop) < 0)
     {
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio can't start mainloop");
         goto fail;
     }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -334,7 +334,9 @@ error:
 void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
 {
     const pa_buffer_attr *a;
+    /* If you need debug pring enable these
     char cmt[PA_CHANNEL_MAP_SNPRINT_MAX], sst[PA_SAMPLE_SPEC_SNPRINT_MAX];
+    */
 
     assert(s);
 
@@ -350,17 +352,15 @@ void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
     switch (pa_stream_get_state(s))
     {
     case PA_STREAM_TERMINATED:
-        /* printf("TERMINATED!\n"); */
         break;
 
     case PA_STREAM_CREATING:
-        /* printf("CREATING!\n"); */
         break;
 
     case PA_STREAM_READY:
-        /* printf("READY!\n"); */
+        /* Mainly here is you need debug printing
 
-        /*fprintf(stderr, "PulseaudioStreamStateCb: Stream successfully created.\n");
+          fprintf(stderr, "PulseaudioStreamStateCb: Stream successfully created.\n");
 
         if (!(a = pa_stream_get_buffer_attr(s)))
             fprintf(stderr, "pa_stream_get_buffer_attr() failed: %s\n", pa_strerror(pa_context_errno(pa_stream_get_context(s))));

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -1,3 +1,4 @@
+
 /*
  * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
  * PulseAudio host to play natively in Linux based systems without
@@ -49,7 +50,7 @@
 */
 
 
-#include <string.h> /* strlen() */
+#include <string.h>     /* strlen() */
 
 
 #include "pa_hostapi_pulseaudio.h"
@@ -66,24 +67,28 @@
 extern char *__progname;
 
 /* PulseAudio specific functions */
-int PulseAudioCheckConnection(PaPulseAudioHostApiRepresentation *ptr)
+int PulseAudioCheckConnection(
+    PaPulseAudioHostApiRepresentation * ptr
+)
 {
     pa_context_state_t state;
 
     assert(ptr);
 
     /* Sanity check if pre if NULL don't go anywhere or
-       it will SIGSEGV
+     * it will SIGSEGV
      */
-    if(!ptr)
+    if (!ptr)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "Host API is NULL! Can't do anything about it");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "Host API is NULL! Can't do anything about it");
         return -1;
     }
 
     if (!ptr->context || !ptr->mainloop)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio context or mainloop are NULL");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudio context or mainloop are NULL");
         return -1;
     }
 
@@ -98,20 +103,24 @@ int PulseAudioCheckConnection(PaPulseAudioHostApiRepresentation *ptr)
     return 0;
 }
 
-PaPulseAudioHostApiRepresentation *PulseAudioNew(void)
+PaPulseAudioHostApiRepresentation *PulseAudioNew(
+    void
+)
 {
     PaPulseAudioHostApiRepresentation *ptr;
     int fd[2] = { -1, -1 };
     char proc[PATH_MAX];
     char buf[PATH_MAX + 20];
 
-    ptr = (PaPulseAudioHostApiRepresentation*)PaUtil_AllocateMemory(sizeof(PaPulseAudioHostApiRepresentation));
+    ptr =
+        (PaPulseAudioHostApiRepresentation *)
+        PaUtil_AllocateMemory(sizeof(PaPulseAudioHostApiRepresentation));
 
     /* prt is NULL if runs out of memory or pointer to allocated memory */
     if (!ptr)
     {
         PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudio can't alloc memory");
-	return NULL;
+        return NULL;
     }
 
     /* Make sure we have NULL all struct first */
@@ -137,7 +146,8 @@ PaPulseAudioHostApiRepresentation *PulseAudioNew(void)
         goto fail;
     }
 
-    pa_context_set_state_callback(ptr->context, PulseAudioCheckContextStateCb, ptr);
+    pa_context_set_state_callback(ptr->context, PulseAudioCheckContextStateCb,
+                                  ptr);
 
 
     if (pa_threaded_mainloop_start(ptr->mainloop) < 0)
@@ -150,21 +160,24 @@ PaPulseAudioHostApiRepresentation *PulseAudioNew(void)
 
     return ptr;
 
-fail:
+  fail:
     PulseAudioFree(ptr);
     return NULL;
 }
 
-void PulseAudioFree(PaPulseAudioHostApiRepresentation *ptr)
+void PulseAudioFree(
+    PaPulseAudioHostApiRepresentation * ptr
+)
 {
     assert(ptr);
 
     /* Sanity check if pre if NULL don't go anywhere or
-       it will SIGSEGV
+     * it will SIGSEGV
      */
-    if(!ptr)
+    if (!ptr)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "Host API is NULL! Can't do anything about it");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "Host API is NULL! Can't do anything about it");
         return;
     }
 
@@ -188,15 +201,19 @@ void PulseAudioFree(PaPulseAudioHostApiRepresentation *ptr)
 }
 
 
-static void PulseAudioCheckContextStateCb(pa_context * c, void *userdata)
+static void PulseAudioCheckContextStateCb(
+    pa_context * c,
+    void *userdata
+)
 {
     PaPulseAudioHostApiRepresentation *ptr = userdata;
     assert(c);
 
     /* If this is null we have big problems and we probably are out of memory */
-    if(!c)
+    if (!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioCheckContextStateCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudioCheckContextStateCb: Out of memory");
         pa_threaded_mainloop_signal(ptr->mainloop, 0);
         return;
     }
@@ -206,18 +223,25 @@ static void PulseAudioCheckContextStateCb(pa_context * c, void *userdata)
 }
 
 
-void PulseAudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata)
+void PulseAudioSinkListCb(
+    pa_context * c,
+    const pa_sink_info * l,
+    int eol,
+    void *userdata
+)
 {
-    PaPulseAudioHostApiRepresentation *l_ptrHostApi = (PaPulseAudioHostApiRepresentation *)userdata;
+    PaPulseAudioHostApiRepresentation *l_ptrHostApi =
+        (PaPulseAudioHostApiRepresentation *) userdata;
     PaError result = paNoError;
     char *l_strName = NULL;
 
     assert(c);
 
     /* If this is null we have big problems and we probably are out of memory */
-    if(!c)
+    if (!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioSinkListCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudioSinkListCb: Out of memory");
         goto error;
     }
 
@@ -228,57 +252,85 @@ void PulseAudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *u
     }
 
     l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi = l_ptrHostApi->hostApiIndex;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
+        l_ptrHostApi->hostApiIndex;
 
-    l_strName = (char *)l->name;
+    l_strName = (char *) l->name;
 
-    if(l->description != NULL)
+    if (l->description != NULL)
     {
-        l_strName = (char *)l->description;
+        l_strName = (char *) l->description;
     }
 
-    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-              strnlen(l->name, 1024) + 1), paInsufficientMemory);
+    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] =
+              (char *) PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+                                                  strnlen(l->name, 1024) + 1),
+              paInsufficientMemory);
 
-    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
-    strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
+    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00,
+           strnlen(l->name, 1024) + 1);
+    strncpy((char *)
+            l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount],
+            l->name, strnlen(l->name, 1024));
 
-    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-              strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name =
+              (char *) PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+                                                  strnlen(l_strName, 1024) + 1),
+              paInsufficientMemory);
 
-    memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
-    strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
+    memset((char *) l_ptrHostApi->
+           deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00,
+           strnlen(l_strName, 1024) + 1);
+    strncpy((char *) l_ptrHostApi->
+            deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName,
+            strnlen(l_strName, 1024));
 
     // l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = l->name;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels = 0;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels = l->sample_spec.channels;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels =
+        0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels =
+        l->sample_spec.channels;
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowInputLatency = 0.;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowOutputLatency = l->latency;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighInputLatency = 0.;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighOutputLatency = l->configured_latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultLowInputLatency = 0.;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultLowOutputLatency =
+        l->latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultHighInputLatency = 0.;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultHighOutputLatency =
+        l->configured_latency;
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate = l->sample_spec.rate;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate =
+        l->sample_spec.rate;
 
-    l_ptrHostApi->deviceCount ++;
+    l_ptrHostApi->deviceCount++;
 
-error:
+  error:
     pa_threaded_mainloop_signal(l_ptrHostApi->mainloop, 0);
 }
 
 
-void PulseAudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata)
+void PulseAudioSourceListCb(
+    pa_context * c,
+    const pa_source_info * l,
+    int eol,
+    void *userdata
+)
 {
-    PaPulseAudioHostApiRepresentation *l_ptrHostApi = (PaPulseAudioHostApiRepresentation *)userdata;
+    PaPulseAudioHostApiRepresentation *l_ptrHostApi =
+        (PaPulseAudioHostApiRepresentation *) userdata;
     PaError result = paNoError;
     char *l_strName = NULL;
 
     assert(c);
 
     /* If this is null we have big problems and we probably are out of memory */
-    if(!c)
+    if (!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioSourceListCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudioSourceListCb: Out of memory");
         goto error;
     }
 
@@ -289,61 +341,86 @@ void PulseAudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, voi
     }
 
     l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi = l_ptrHostApi->hostApiIndex;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
+        l_ptrHostApi->hostApiIndex;
 
-    l_strName = (char *)l->name;
+    l_strName = (char *) l->name;
 
-    if(l->description != NULL)
+    if (l->description != NULL)
     {
-        l_strName = (char *)l->description;
+        l_strName = (char *) l->description;
     }
 
     printf("%s Source name: %s (%s)\n", __FUNCTION__, l->name, l->description);
 
-    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-              strnlen(l->name, 1024) + 1), paInsufficientMemory);
+    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] =
+              (char *) PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+                                                  strnlen(l->name, 1024) + 1),
+              paInsufficientMemory);
 
-    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
-    strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
+    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00,
+           strnlen(l->name, 1024) + 1);
+    strncpy((char *)
+            l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount],
+            l->name, strnlen(l->name, 1024));
 
-    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-              strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name =
+              (char *) PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+                                                  strnlen(l_strName, 1024) + 1),
+              paInsufficientMemory);
 
-    memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
-    strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
+    memset((char *) l_ptrHostApi->
+           deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00,
+           strnlen(l_strName, 1024) + 1);
+    strncpy((char *) l_ptrHostApi->
+            deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName,
+            strnlen(l_strName, 1024));
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels = l->sample_spec.channels;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels = 0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels =
+        l->sample_spec.channels;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels =
+        0;
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowInputLatency = (double)l->latency;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowOutputLatency = 0;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighInputLatency = (double)l->configured_latency;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighOutputLatency = 0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultLowInputLatency =
+        (double) l->latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultLowOutputLatency = 0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultHighInputLatency =
+        (double) l->configured_latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->
+                                  deviceCount].defaultHighOutputLatency = 0;
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate = l->sample_spec.rate;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate =
+        l->sample_spec.rate;
 
-    l_ptrHostApi->deviceCount ++;
+    l_ptrHostApi->deviceCount++;
 
-error:
-    PA_DEBUG(("Portaudio %s: End of list\n",__FUNCTION__));
+  error:
+    PA_DEBUG(("Portaudio %s: End of list\n", __FUNCTION__));
 
     pa_threaded_mainloop_signal(l_ptrHostApi->mainloop, 0);
 }
 
 /* This routine is called whenever the stream state changes */
-void PulseAudioStreamStateCb(pa_stream *s, void *userdata)
+void PulseAudioStreamStateCb(
+    pa_stream * s,
+    void *userdata
+)
 {
     const pa_buffer_attr *a;
     /* If you need debug pring enable these
-    char cmt[PA_CHANNEL_MAP_SNPRINT_MAX], sst[PA_SAMPLE_SPEC_SNPRINT_MAX];
-    */
+     * char cmt[PA_CHANNEL_MAP_SNPRINT_MAX], sst[PA_SAMPLE_SPEC_SNPRINT_MAX];
+     */
 
     assert(s);
 
     /* If this is null we have big problems and we probably are out of memory */
-    if(!s)
+    if (!s)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioStreamStateCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudioStreamStateCb: Out of memory");
         return;
     }
 
@@ -351,51 +428,56 @@ void PulseAudioStreamStateCb(pa_stream *s, void *userdata)
 
     switch (pa_stream_get_state(s))
     {
-    case PA_STREAM_TERMINATED:
-        break;
+        case PA_STREAM_TERMINATED:
+            break;
 
-    case PA_STREAM_CREATING:
-        break;
+        case PA_STREAM_CREATING:
+            break;
 
-    case PA_STREAM_READY:
-        /* Mainly here is you need debug printing
+        case PA_STREAM_READY:
+            /* Mainly here is you need debug printing
+             * 
+             * fprintf(stderr, "PulseAudioStreamStateCb: Stream successfully created.\n");
+             * 
+             * if (!(a = pa_stream_get_buffer_attr(s)))
+             * fprintf(stderr, "pa_stream_get_buffer_attr() failed: %s\n", pa_strerror(pa_context_errno(pa_stream_get_context(s))));
+             * else {
+             * fprintf(stderr, "PulseAudioStreamStateCb: Buffer metrics: maxlength=%u, tlength=%u, prebuf=%u, minreq=%u\n", a->maxlength, a->tlength, a->prebuf, a->minreq);
+             * }
+             * 
+             * fprintf(stderr, "PulseAudioStreamStateCb: Using sample spec '%s', channel map '%s'.\n",
+             * pa_sample_spec_snprint(sst, sizeof(sst), pa_stream_get_sample_spec(s)),
+             * pa_channel_map_snprint(cmt, sizeof(cmt), pa_stream_get_channel_map(s)));
+             * 
+             * fprintf(stderr, "PulseAudioStreamStateCb: Connected to device %s (%u, %ssuspended).\n",
+             * pa_stream_get_device_name(s),
+             * pa_stream_get_device_index(s),
+             * pa_stream_is_suspended(s) ? "" : "not "); */
+            break;
 
-          fprintf(stderr, "PulseAudioStreamStateCb: Stream successfully created.\n");
+        case PA_STREAM_FAILED:
+        default:
+            PA_DEBUG(("Portaudio %s: FAILED '%s'\n", __FUNCTION__,
+                      pa_strerror(pa_context_errno(pa_stream_get_context(s)))));
 
-        if (!(a = pa_stream_get_buffer_attr(s)))
-            fprintf(stderr, "pa_stream_get_buffer_attr() failed: %s\n", pa_strerror(pa_context_errno(pa_stream_get_context(s))));
-        else {
-                fprintf(stderr, "PulseAudioStreamStateCb: Buffer metrics: maxlength=%u, tlength=%u, prebuf=%u, minreq=%u\n", a->maxlength, a->tlength, a->prebuf, a->minreq);
-        }
-
-        fprintf(stderr, "PulseAudioStreamStateCb: Using sample spec '%s', channel map '%s'.\n",
-                pa_sample_spec_snprint(sst, sizeof(sst), pa_stream_get_sample_spec(s)),
-                pa_channel_map_snprint(cmt, sizeof(cmt), pa_stream_get_channel_map(s)));
-
-        fprintf(stderr, "PulseAudioStreamStateCb: Connected to device %s (%u, %ssuspended).\n",
-                pa_stream_get_device_name(s),
-                pa_stream_get_device_index(s),
-                pa_stream_is_suspended(s) ? "" : "not ");*/
-        break;
-
-    case PA_STREAM_FAILED:
-    default:
-        PA_DEBUG(("Portaudio %s: FAILED '%s'\n",__FUNCTION__, pa_strerror(pa_context_errno(pa_stream_get_context(s)))));
-
-        break;
+            break;
     }
 }
 
-void PulseAudioStreamUnderflowCb(pa_stream *s, void *userdata)
+void PulseAudioStreamUnderflowCb(
+    pa_stream * s,
+    void *userdata
+)
 {
-    PaPulseAudioStream *stream = (PaPulseAudioStream*)userdata;
+    PaPulseAudioStream *stream = (PaPulseAudioStream *) userdata;
 
     assert(s);
 
     /* If this is null we have big problems and we probably are out of memory */
-    if(!s)
+    if (!s)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioStreamUnderflowCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
+                                          "PulseAudioStreamUnderflowCb: Out of memory");
         return;
     }
 
@@ -404,18 +486,24 @@ void PulseAudioStreamUnderflowCb(pa_stream *s, void *userdata)
     if (stream->underflows >= 6 && stream->latency < 2000000)
     {
         stream->latency = (stream->latency * 3) / 2;
-        stream->bufferAttr.maxlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
-        stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+        stream->bufferAttr.maxlength =
+            pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+        stream->bufferAttr.tlength =
+            pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
         pa_stream_set_buffer_attr(s, &stream->bufferAttr, NULL, NULL);
         stream->underflows = 0;
-        PA_DEBUG(("Portaudio %s: latency increased to %d\n", __FUNCTION__, stream->latency));
+        PA_DEBUG(("Portaudio %s: latency increased to %d\n", __FUNCTION__,
+                  stream->latency));
     }
 
     pa_threaded_mainloop_signal(stream->mainloop, 0);
 }
 
 
-PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex)
+PaError PaPulseAudio_Initialize(
+    PaUtilHostApiRepresentation ** hostApi,
+    PaHostApiIndex hostApiIndex
+)
 {
     PaError result = paNoError;
     int i;
@@ -427,7 +515,7 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
 
     l_ptrPulseAudioHostApi = PulseAudioNew();
 
-    if(!l_ptrPulseAudioHostApi)
+    if (!l_ptrPulseAudioHostApi)
     {
         result = paInsufficientMemory;
         goto error;
@@ -435,7 +523,7 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
 
     l_ptrPulseAudioHostApi->allocations = PaUtil_CreateAllocationGroup();
 
-    if(!l_ptrPulseAudioHostApi->allocations)
+    if (!l_ptrPulseAudioHostApi->allocations)
     {
         PulseAudioFree(l_ptrPulseAudioHostApi);
         result = paInsufficientMemory;
@@ -454,34 +542,34 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
     /* Connect to server */
     pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
 
-    while(1)
+    while (1)
     {
         pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
         switch (l_ptrPulseAudioHostApi->state)
         {
-        case PA_CONTEXT_READY:
-            break;
+            case PA_CONTEXT_READY:
+                break;
 
-        case PA_CONTEXT_TERMINATED:
-        case PA_CONTEXT_FAILED:
-            goto error;
-            break;
-        case PA_CONTEXT_UNCONNECTED:
-            break;
+            case PA_CONTEXT_TERMINATED:
+            case PA_CONTEXT_FAILED:
+                goto error;
+                break;
+            case PA_CONTEXT_UNCONNECTED:
+                break;
 
 
-        case PA_CONTEXT_CONNECTING:
-            break;
+            case PA_CONTEXT_CONNECTING:
+                break;
 
-        case PA_CONTEXT_AUTHORIZING:
-            break;
+            case PA_CONTEXT_AUTHORIZING:
+                break;
 
-        case PA_CONTEXT_SETTING_NAME:
-            break;
+            case PA_CONTEXT_SETTING_NAME:
+                break;
         }
 
-        if(l_ptrPulseAudioHostApi->state == PA_CONTEXT_READY)
+        if (l_ptrPulseAudioHostApi->state == PA_CONTEXT_READY)
         {
             pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
             break;
@@ -493,15 +581,17 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
-    for(i = 0; i < 1024; i ++)
+    for (i = 0; i < 1024; i++)
     {
-        memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00, sizeof(PaDeviceInfo) * 1024);
+        memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00,
+               sizeof(PaDeviceInfo) * 1024);
         l_ptrPulseAudioHostApi->pulseaudioDeviceNames[i] = NULL;
     }
 
-    l_ptrOperation = pa_context_get_sink_info_list(l_ptrPulseAudioHostApi->context,
-                     PulseAudioSinkListCb,
-                     l_ptrPulseAudioHostApi);
+    l_ptrOperation =
+        pa_context_get_sink_info_list(l_ptrPulseAudioHostApi->context,
+                                      PulseAudioSinkListCb,
+                                      l_ptrPulseAudioHostApi);
 
     pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
@@ -513,9 +603,10 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
     pa_operation_unref(l_ptrOperation);
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
-    l_ptrOperation = pa_context_get_source_info_list(l_ptrPulseAudioHostApi->context,
-                     PulseAudioSourceListCb,
-                     l_ptrPulseAudioHostApi);
+    l_ptrOperation =
+        pa_context_get_source_info_list(l_ptrPulseAudioHostApi->context,
+                                        PulseAudioSourceListCb,
+                                        l_ptrPulseAudioHostApi);
 
     pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
@@ -528,36 +619,42 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
 
     (*hostApi)->info.deviceCount = l_ptrPulseAudioHostApi->deviceCount;
 
-    if(l_ptrPulseAudioHostApi->deviceCount > 0)
+    if (l_ptrPulseAudioHostApi->deviceCount > 0)
     {
         /* If you have over 1024 Audio devices.. shame on you! */
 
-        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
-                                      l_ptrPulseAudioHostApi->allocations, sizeof(PaDeviceInfo*) * l_ptrPulseAudioHostApi->deviceCount);
+        (*hostApi)->deviceInfos =
+            (PaDeviceInfo **)
+            PaUtil_GroupAllocateMemory(l_ptrPulseAudioHostApi->allocations,
+                                       sizeof(PaDeviceInfo *) *
+                                       l_ptrPulseAudioHostApi->deviceCount);
 
-        if(!(*hostApi)->deviceInfos)
+        if (!(*hostApi)->deviceInfos)
         {
             result = paInsufficientMemory;
             goto error;
         }
 
-        for(i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i ++)
+        for (i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i++)
         {
-            (*hostApi)->deviceInfos[i] = &l_ptrPulseAudioHostApi->deviceInfoArray[i];
+            (*hostApi)->deviceInfos[i] =
+                &l_ptrPulseAudioHostApi->deviceInfoArray[i];
         }
 
         /* First should be the default */
         (*hostApi)->info.defaultInputDevice = -1;
         (*hostApi)->info.defaultOutputDevice = -1;
 
-        for(i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i ++)
+        for (i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i++)
         {
-            if(l_ptrPulseAudioHostApi->deviceInfoArray[i].maxInputChannels > 0 && (*hostApi)->info.defaultInputDevice == -1)
+            if (l_ptrPulseAudioHostApi->deviceInfoArray[i].maxInputChannels > 0
+                && (*hostApi)->info.defaultInputDevice == -1)
             {
                 (*hostApi)->info.defaultInputDevice = i;
             }
 
-            if(l_ptrPulseAudioHostApi->deviceInfoArray[i].maxOutputChannels > 0 && (*hostApi)->info.defaultOutputDevice == -1)
+            if (l_ptrPulseAudioHostApi->deviceInfoArray[i].maxOutputChannels > 0
+                && (*hostApi)->info.defaultOutputDevice == -1)
             {
                 (*hostApi)->info.defaultOutputDevice = i;
             }
@@ -570,41 +667,30 @@ PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    PaUtil_InitializeStreamInterface(&l_ptrPulseAudioHostApi->callbackStreamInterface,
-                                     PulseAudioCloseStreamCb,
-                                     PulseAudioStartStreamCb,
-                                     PulseAudioStopStreamCb,
-                                     PulseAudioAbortStreamCb,
-                                     IsStreamStopped,
-                                     IsStreamActive,
-                                     GetStreamTime,
-                                     GetStreamCpuLoad,
-                                     PaUtil_DummyRead,
-                                     PaUtil_DummyWrite,
-                                     PaUtil_DummyGetReadAvailable,
-                                     PaUtil_DummyGetWriteAvailable);
+    PaUtil_InitializeStreamInterface
+        (&l_ptrPulseAudioHostApi->callbackStreamInterface,
+         PulseAudioCloseStreamCb, PulseAudioStartStreamCb,
+         PulseAudioStopStreamCb, PulseAudioAbortStreamCb, IsStreamStopped,
+         IsStreamActive, GetStreamTime, GetStreamCpuLoad, PaUtil_DummyRead,
+         PaUtil_DummyWrite, PaUtil_DummyGetReadAvailable,
+         PaUtil_DummyGetWriteAvailable);
 
-    PaUtil_InitializeStreamInterface(&l_ptrPulseAudioHostApi->blockingStreamInterface,
-                                     PulseAudioCloseStreamCb,
-                                     PulseAudioStartStreamCb,
-                                     PulseAudioStopStreamCb,
-                                     PulseAudioAbortStreamCb,
-                                     IsStreamStopped,
-                                     IsStreamActive,
-                                     GetStreamTime,
-                                     PaUtil_DummyGetCpuLoad,
-                                     PulseAudioReadStreamBlock,
-                                     PulseAudioWriteStreamBlock,
-                                     PulseAudioGetStreamReadAvailableBlock,
-                                     PulseAudioGetStreamWriteAvailableBlock);
+    PaUtil_InitializeStreamInterface
+        (&l_ptrPulseAudioHostApi->blockingStreamInterface,
+         PulseAudioCloseStreamCb, PulseAudioStartStreamCb,
+         PulseAudioStopStreamCb, PulseAudioAbortStreamCb, IsStreamStopped,
+         IsStreamActive, GetStreamTime, PaUtil_DummyGetCpuLoad,
+         PulseAudioReadStreamBlock, PulseAudioWriteStreamBlock,
+         PulseAudioGetStreamReadAvailableBlock,
+         PulseAudioGetStreamWriteAvailableBlock);
 
     return result;
 
-error:
+  error:
 
-    if(l_ptrPulseAudioHostApi)
+    if (l_ptrPulseAudioHostApi)
     {
-        if(l_ptrPulseAudioHostApi->allocations)
+        if (l_ptrPulseAudioHostApi->allocations)
         {
             PaUtil_FreeAllAllocations(l_ptrPulseAudioHostApi->allocations);
             PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
@@ -617,11 +703,14 @@ error:
 }
 
 
-static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
+static void Terminate(
+    struct PaUtilHostApiRepresentation *hostApi
+)
 {
-    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = (PaPulseAudioHostApiRepresentation*)hostApi;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi =
+        (PaPulseAudioHostApiRepresentation *) hostApi;
 
-    if(l_ptrPulseAudioHostApi->allocations)
+    if (l_ptrPulseAudioHostApi->allocations)
     {
         PaUtil_FreeAllAllocations(l_ptrPulseAudioHostApi->allocations);
         PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
@@ -633,44 +722,49 @@ static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
 }
 
 
-static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
-                                 const PaStreamParameters *inputParameters,
-                                 const PaStreamParameters *outputParameters,
-                                 double sampleRate)
+static PaError IsFormatSupported(
+    struct PaUtilHostApiRepresentation *hostApi,
+    const PaStreamParameters * inputParameters,
+    const PaStreamParameters * outputParameters,
+    double sampleRate
+)
 {
-    int inputChannelCount, outputChannelCount;
-    PaSampleFormat inputSampleFormat, outputSampleFormat;
+    int inputChannelCount,
+     outputChannelCount;
+    PaSampleFormat inputSampleFormat,
+     outputSampleFormat;
 
-    if(inputParameters)
+    if (inputParameters)
     {
         inputChannelCount = inputParameters->channelCount;
         inputSampleFormat = inputParameters->sampleFormat;
 
         /* all standard sample formats are supported by the buffer adapter,
-            this implementation doesn't support any custom sample formats */
-        if(inputSampleFormat & paCustomFormat)
+         * this implementation doesn't support any custom sample formats */
+        if (inputSampleFormat & paCustomFormat)
         {
             return paSampleFormatNotSupported;
         }
 
         /* unless alternate device specification is supported, reject the use of
-            paUseHostApiSpecificDeviceSpecification */
+         * paUseHostApiSpecificDeviceSpecification */
 
-        if(inputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        if (inputParameters->device == paUseHostApiSpecificDeviceSpecification)
         {
             return paInvalidDevice;
         }
 
         /* check that input device can support inputChannelCount */
-        if(inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels)
+        if (inputChannelCount >
+            hostApi->deviceInfos[inputParameters->device]->maxInputChannels)
         {
             return paInvalidChannelCount;
         }
 
         /* validate inputStreamInfo */
-        if(inputParameters->hostApiSpecificStreamInfo)
+        if (inputParameters->hostApiSpecificStreamInfo)
         {
-            return paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            return paIncompatibleHostApiSpecificStreamInfo;     /* this implementation doesn't use custom stream info */
         }
 
     }
@@ -680,36 +774,37 @@ static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
         inputChannelCount = 0;
     }
 
-    if(outputParameters)
+    if (outputParameters)
     {
         outputChannelCount = outputParameters->channelCount;
         outputSampleFormat = outputParameters->sampleFormat;
 
         /* all standard sample formats are supported by the buffer adapter,
-            this implementation doesn't support any custom sample formats */
-        if(outputSampleFormat & paCustomFormat)
+         * this implementation doesn't support any custom sample formats */
+        if (outputSampleFormat & paCustomFormat)
         {
             return paSampleFormatNotSupported;
         }
 
         /* unless alternate device specification is supported, reject the use of
-            paUseHostApiSpecificDeviceSpecification */
+         * paUseHostApiSpecificDeviceSpecification */
 
-        if(outputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        if (outputParameters->device == paUseHostApiSpecificDeviceSpecification)
         {
             return paInvalidDevice;
         }
 
         /* check that output device can support outputChannelCount */
-        if(outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels)
+        if (outputChannelCount >
+            hostApi->deviceInfos[outputParameters->device]->maxOutputChannels)
         {
             return paInvalidChannelCount;
         }
 
         /* validate outputStreamInfo */
-        if(outputParameters->hostApiSpecificStreamInfo)
+        if (outputParameters->hostApiSpecificStreamInfo)
         {
-            return paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            return paIncompatibleHostApiSpecificStreamInfo;     /* this implementation doesn't use custom stream info */
         }
 
     }
@@ -720,25 +815,25 @@ static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
     }
 
     /*
-        IMPLEMENT ME:
-
-            - if a full duplex stream is requested, check that the combination
-                of input and output parameters is supported if necessary
-
-            - check that the device supports sampleRate
-
-        Because the buffer adapter handles conversion between all standard
-        sample formats, the following checks are only required if paCustomFormat
-        is implemented, or under some other unusual conditions.
-
-            - check that input device can support inputSampleFormat, or that
-                we have the capability to convert from inputSampleFormat to
-                a native format
-
-            - check that output device can support outputSampleFormat, or that
-                we have the capability to convert from outputSampleFormat to
-                a native format
-    */
+     * IMPLEMENT ME:
+     * 
+     * - if a full duplex stream is requested, check that the combination
+     * of input and output parameters is supported if necessary
+     * 
+     * - check that the device supports sampleRate
+     * 
+     * Because the buffer adapter handles conversion between all standard
+     * sample formats, the following checks are only required if paCustomFormat
+     * is implemented, or under some other unusual conditions.
+     * 
+     * - check that input device can support inputSampleFormat, or that
+     * we have the capability to convert from inputSampleFormat to
+     * a native format
+     * 
+     * - check that output device can support outputSampleFormat, or that
+     * we have the capability to convert from outputSampleFormat to
+     * a native format
+     */
 
 
     /* suppress unused variable warnings */
@@ -747,40 +842,43 @@ static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
     return paFormatIsSupported;
 }
 
-PaError PulseAudioConvertPortaudioFormatToPulseAudio(PaSampleFormat portaudiosf,
-        pa_sample_spec *pulseaudiosf)
+PaError PulseAudioConvertPortaudioFormatToPulseAudio(
+    PaSampleFormat portaudiosf,
+    pa_sample_spec * pulseaudiosf
+)
 {
-    switch(portaudiosf)
+    switch (portaudiosf)
     {
-    case paFloat32:
-        pulseaudiosf->format = PA_SAMPLE_FLOAT32LE;
-        break;
+        case paFloat32:
+            pulseaudiosf->format = PA_SAMPLE_FLOAT32LE;
+            break;
 
-    case paInt32:
-        pulseaudiosf->format = PA_SAMPLE_S32LE;
-        break;
+        case paInt32:
+            pulseaudiosf->format = PA_SAMPLE_S32LE;
+            break;
 
-    case paInt24:
-        pulseaudiosf->format = PA_SAMPLE_S24LE;
-        break;
+        case paInt24:
+            pulseaudiosf->format = PA_SAMPLE_S24LE;
+            break;
 
-    case paInt16:
-        pulseaudiosf->format = PA_SAMPLE_S16LE;
-        break;
+        case paInt16:
+            pulseaudiosf->format = PA_SAMPLE_S16LE;
+            break;
 
-    case paInt8:
-        pulseaudiosf->format = PA_SAMPLE_U8;
-        break;
+        case paInt8:
+            pulseaudiosf->format = PA_SAMPLE_U8;
+            break;
 
-    case paUInt8:
-        pulseaudiosf->format = PA_SAMPLE_U8;
-        break;
+        case paUInt8:
+            pulseaudiosf->format = PA_SAMPLE_U8;
+            break;
 
-    case paCustomFormat:
-    case paNonInterleaved:
-        PA_DEBUG(("PulseAudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n", __FUNCTION__));
-        return paNotInitialized;
-        break;
+        case paCustomFormat:
+        case paNonInterleaved:
+            PA_DEBUG(("PulseAudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n",
+                      __FUNCTION__));
+            return paNotInitialized;
+            break;
     }
 
     return paNoError;
@@ -788,51 +886,64 @@ PaError PulseAudioConvertPortaudioFormatToPulseAudio(PaSampleFormat portaudiosf,
 
 
 /* Allocate buffer. */
-static PaError PulseAudioBlockingInitRingBuffer(PaPulseAudioStream *stream, PaUtilRingBuffer *rbuf, int size)
+static PaError PulseAudioBlockingInitRingBuffer(
+    PaPulseAudioStream * stream,
+    PaUtilRingBuffer * rbuf,
+    int size
+)
 {
     long l_lNumBytes = 4096 * size;
-    char *l_ptrBuffer = (char *) malloc( l_lNumBytes );
+    char *l_ptrBuffer = (char *) malloc(l_lNumBytes);
 
-    if( l_ptrBuffer == NULL )
+    if (l_ptrBuffer == NULL)
     {
         return paInsufficientMemory;
     }
 
-    memset( l_ptrBuffer, 0x00, l_lNumBytes );
-    return (PaError) PaUtil_InitializeRingBuffer( rbuf, 1, l_lNumBytes, l_ptrBuffer );
+    memset(l_ptrBuffer, 0x00, l_lNumBytes);
+    return (PaError) PaUtil_InitializeRingBuffer(rbuf, 1, l_lNumBytes,
+                                                 l_ptrBuffer);
 }
 
 /* see pa_hostapi.h for a list of validity guarantees made about OpenStream parameters */
 
-static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
-                          PaStream** s,
-                          const PaStreamParameters *inputParameters,
-                          const PaStreamParameters *outputParameters,
-                          double sampleRate,
-                          unsigned long framesPerBuffer,
-                          PaStreamFlags streamFlags,
-                          PaStreamCallback *streamCallback,
-                          void *userData)
+static PaError OpenStream(
+    struct PaUtilHostApiRepresentation *hostApi,
+    PaStream ** s,
+    const PaStreamParameters * inputParameters,
+    const PaStreamParameters * outputParameters,
+    double sampleRate,
+    unsigned long framesPerBuffer,
+    PaStreamFlags streamFlags,
+    PaStreamCallback * streamCallback,
+    void *userData
+)
 {
     PaError result = paNoError;
-    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = (PaPulseAudioHostApiRepresentation*)hostApi;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi =
+        (PaPulseAudioHostApiRepresentation *) hostApi;
     PaPulseAudioStream *stream = NULL;
-    unsigned long framesPerHostBuffer = framesPerBuffer; /* these may not be equivalent for all implementations */
-    int inputChannelCount, outputChannelCount;
-    PaSampleFormat inputSampleFormat, outputSampleFormat;
-    PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
+    unsigned long framesPerHostBuffer = framesPerBuffer;        /* these may not be equivalent for all implementations */
+    int inputChannelCount,
+     outputChannelCount;
+    PaSampleFormat inputSampleFormat,
+     outputSampleFormat;
+    PaSampleFormat hostInputSampleFormat,
+     hostOutputSampleFormat;
 
     /* validate platform specific flags */
-    if((streamFlags & paPlatformSpecificFlags) != 0)
+    if ((streamFlags & paPlatformSpecificFlags) != 0)
     {
-        return paInvalidFlag;    /* unexpected platform specific flag */
+        return paInvalidFlag;   /* unexpected platform specific flag */
     }
 
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
-    stream = (PaPulseAudioStream*)PaUtil_AllocateMemory(sizeof(PaPulseAudioStream));
+    stream =
+        (PaPulseAudioStream *)
+        PaUtil_AllocateMemory(sizeof(PaPulseAudioStream));
 
-    if(!stream)
+    if (!stream)
     {
         result = paInsufficientMemory;
         goto error;
@@ -849,69 +960,81 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
     memset(&stream->inputRing, 0x00, sizeof(PaUtilRingBuffer));
 
 
-    if(inputParameters)
+    if (inputParameters)
     {
         inputChannelCount = inputParameters->channelCount;
         inputSampleFormat = inputParameters->sampleFormat;
 
         /* unless alternate device specification is supported, reject the use of
-            paUseHostApiSpecificDeviceSpecification */
+         * paUseHostApiSpecificDeviceSpecification */
 
-        if(inputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        if (inputParameters->device == paUseHostApiSpecificDeviceSpecification)
         {
             result = paInvalidDevice;
             goto error;
         }
 
         /* check that input device can support inputChannelCount */
-        if(inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels)
+        if (inputChannelCount >
+            hostApi->deviceInfos[inputParameters->device]->maxInputChannels)
         {
             result = paInvalidChannelCount;
             goto error;
         }
 
         /* validate inputStreamInfo */
-        if(inputParameters->hostApiSpecificStreamInfo)
+        if (inputParameters->hostApiSpecificStreamInfo)
         {
-            result = paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            result = paIncompatibleHostApiSpecificStreamInfo;   /* this implementation doesn't use custom stream info */
             goto error;
         }
 
         hostInputSampleFormat =
-            PaUtil_SelectClosestAvailableFormat(inputSampleFormat, inputSampleFormat);
+            PaUtil_SelectClosestAvailableFormat(inputSampleFormat,
+                                                inputSampleFormat);
 
-        stream->inputFrameSize = Pa_GetSampleSize(inputSampleFormat) * inputChannelCount;
+        stream->inputFrameSize =
+            Pa_GetSampleSize(inputSampleFormat) * inputChannelCount;
 
-        PulseAudioConvertPortaudioFormatToPulseAudio(inputSampleFormat, &stream->inSampleSpec);
+        PulseAudioConvertPortaudioFormatToPulseAudio(inputSampleFormat,
+                                                     &stream->inSampleSpec);
         stream->inSampleSpec.rate = sampleRate;
         stream->inSampleSpec.channels = inputChannelCount;
 
-        if(!pa_sample_spec_valid(&stream->inSampleSpec   ))
+        if (!pa_sample_spec_valid(&stream->inSampleSpec))
         {
-            PA_DEBUG(("Portaudio %s: Invalid input audio spec!\n",__FUNCTION__));
+            PA_DEBUG(("Portaudio %s: Invalid input audio spec!\n",
+                      __FUNCTION__));
             goto error;
         }
 
-        stream->inStream = pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio source", &stream->inSampleSpec, NULL);
+        stream->inStream =
+            pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio source",
+                          &stream->inSampleSpec, NULL);
 
-        if(stream->inStream != NULL)
+        if (stream->inStream != NULL)
         {
-            pa_stream_set_state_callback(stream->inStream, PulseAudioStreamStateCb, NULL);
-            pa_stream_set_started_callback(stream->inStream, PulseAudioStreamStartedCb, NULL);
-            pa_stream_set_read_callback(stream->inStream, PulseAudioStreamReadCb, stream);
+            pa_stream_set_state_callback(stream->inStream,
+                                         PulseAudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->inStream,
+                                           PulseAudioStreamStartedCb, NULL);
+            pa_stream_set_read_callback(stream->inStream,
+                                        PulseAudioStreamReadCb, stream);
 
         }
 
         else
         {
-            PA_DEBUG(("Portaudio %s: Can't alloc input stream!\n", __FUNCTION__));
+            PA_DEBUG(("Portaudio %s: Can't alloc input stream!\n",
+                      __FUNCTION__));
         }
 
         stream->device = inputParameters->device;
 
-        if(!streamCallback)
+        if (!streamCallback)
         {
-            PulseAudioBlockingInitRingBuffer(stream, &stream->inputRing, stream->inputFrameSize);
+            PulseAudioBlockingInitRingBuffer(stream, &stream->inputRing,
+                                             stream->inputFrameSize);
         }
 
     }
@@ -922,68 +1045,83 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
         inputSampleFormat = hostInputSampleFormat = paFloat32;
     }
 
-    if(outputParameters)
+    if (outputParameters)
     {
         outputChannelCount = outputParameters->channelCount;
         outputSampleFormat = outputParameters->sampleFormat;
 
         /* unless alternate device specification is supported, reject the use of
-            paUseHostApiSpecificDeviceSpecification */
+         * paUseHostApiSpecificDeviceSpecification */
 
-        if(outputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        if (outputParameters->device == paUseHostApiSpecificDeviceSpecification)
         {
             result = paInvalidDevice;
             goto error;
         }
 
         /* check that output device can support inputChannelCount */
-        if(outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels)
+        if (outputChannelCount >
+            hostApi->deviceInfos[outputParameters->device]->maxOutputChannels)
         {
             result = paInvalidChannelCount;
             goto error;
         }
 
         /* validate outputStreamInfo */
-        if(outputParameters->hostApiSpecificStreamInfo)
+        if (outputParameters->hostApiSpecificStreamInfo)
         {
-            result = paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            result = paIncompatibleHostApiSpecificStreamInfo;   /* this implementation doesn't use custom stream info */
             goto error;
         }
 
         /* IMPLEMENT ME - establish which  host formats are available */
         hostOutputSampleFormat =
-            PaUtil_SelectClosestAvailableFormat(outputSampleFormat /* native formats */, outputSampleFormat);
+            PaUtil_SelectClosestAvailableFormat(outputSampleFormat
+                                                /* native formats */ ,
+                                                outputSampleFormat);
 
-        stream->outputFrameSize = Pa_GetSampleSize(outputSampleFormat) * outputChannelCount;
+        stream->outputFrameSize =
+            Pa_GetSampleSize(outputSampleFormat) * outputChannelCount;
 
-        PulseAudioConvertPortaudioFormatToPulseAudio(outputSampleFormat, &stream->outSampleSpec);
+        PulseAudioConvertPortaudioFormatToPulseAudio(outputSampleFormat,
+                                                     &stream->outSampleSpec);
         stream->outSampleSpec.rate = sampleRate;
         stream->outSampleSpec.channels = outputChannelCount;
 
-        if(!pa_sample_spec_valid(&stream->outSampleSpec  ))
+        if (!pa_sample_spec_valid(&stream->outSampleSpec))
         {
-            PA_DEBUG(("Portaudio %s: Invalid audio spec for output!\n", __FUNCTION__));
+            PA_DEBUG(("Portaudio %s: Invalid audio spec for output!\n",
+                      __FUNCTION__));
             goto error;
         }
 
-        stream->outStream = pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio sink", &stream->outSampleSpec, NULL);
+        stream->outStream =
+            pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio sink",
+                          &stream->outSampleSpec, NULL);
 
-        if(stream->outStream != NULL)
+        if (stream->outStream != NULL)
         {
-            pa_stream_set_state_callback(stream->outStream, PulseAudioStreamStateCb, NULL);
-            pa_stream_set_started_callback(stream->outStream, PulseAudioStreamStartedCb, NULL);
-            pa_stream_set_write_callback(stream->outStream, PulseAudioStreamWriteCb, stream);
+            pa_stream_set_state_callback(stream->outStream,
+                                         PulseAudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->outStream,
+                                           PulseAudioStreamStartedCb, NULL);
+            pa_stream_set_write_callback(stream->outStream,
+                                         PulseAudioStreamWriteCb, stream);
         }
 
         else
         {
-            PA_DEBUG(("Portaudio %s: Can't alloc output stream!\n", __FUNCTION__));
+            PA_DEBUG(("Portaudio %s: Can't alloc output stream!\n",
+                      __FUNCTION__));
         }
 
-        if(!streamCallback)
+        if (!streamCallback)
         {
             long l_lnumBytes = 0;
-            if( (l_lnumBytes = PulseAudioBlockingInitRingBuffer(stream, &stream->outputRing, stream->outputFrameSize)) != 0)
+            if ((l_lnumBytes =
+                 PulseAudioBlockingInitRingBuffer(stream, &stream->outputRing,
+                                                  stream->outputFrameSize)) !=
+                0)
             {
                 PA_DEBUG(("Portaudio %s: Can't alloc output RingBuffer (Error: %ld)!\n", __FUNCTION__, l_lnumBytes));
                 goto error;
@@ -1005,55 +1143,61 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
     stream->context = l_ptrPulseAudioHostApi->context;
     stream->mainloop = l_ptrPulseAudioHostApi->mainloop;
 
-    if(streamCallback)
+    if (streamCallback)
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                              &l_ptrPulseAudioHostApi->callbackStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseAudioHostApi->callbackStreamInterface,
+                                              streamCallback, userData);
     }
     else
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                              &l_ptrPulseAudioHostApi->blockingStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseAudioHostApi->blockingStreamInterface,
+                                              streamCallback, userData);
     }
 
     PaUtil_InitializeCpuLoadMeasurer(&stream->cpuLoadMeasurer, sampleRate);
 
 
     /* we assume a fixed host buffer size in this example, but the buffer processor
-        can also support bounded and unknown host buffer sizes by passing
-        paUtilBoundedHostBufferSize or paUtilUnknownHostBufferSize instead of
-        paUtilFixedHostBufferSize below. */
+     * can also support bounded and unknown host buffer sizes by passing
+     * paUtilBoundedHostBufferSize or paUtilUnknownHostBufferSize instead of
+     * paUtilFixedHostBufferSize below. */
 
-    result =  PaUtil_InitializeBufferProcessor(&stream->bufferProcessor,
-              inputChannelCount, inputSampleFormat, hostInputSampleFormat,
-              outputChannelCount, outputSampleFormat, hostOutputSampleFormat,
-              sampleRate, streamFlags, framesPerBuffer,
-              framesPerHostBuffer, paUtilUnknownHostBufferSize,
-              streamCallback, userData);
+    result = PaUtil_InitializeBufferProcessor(&stream->bufferProcessor,
+                                              inputChannelCount,
+                                              inputSampleFormat,
+                                              hostInputSampleFormat,
+                                              outputChannelCount,
+                                              outputSampleFormat,
+                                              hostOutputSampleFormat,
+                                              sampleRate, streamFlags,
+                                              framesPerBuffer,
+                                              framesPerHostBuffer,
+                                              paUtilUnknownHostBufferSize,
+                                              streamCallback, userData);
 
-    if(result != paNoError)
+    if (result != paNoError)
     {
         goto error;
     }
 
-    stream->streamRepresentation.streamInfo.inputLatency =
-        (PaTime)PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* inputLatency is specified in _seconds_ */
-    stream->streamRepresentation.streamInfo.outputLatency =
-        (PaTime)PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* outputLatency is specified in _seconds_ */
+    stream->streamRepresentation.streamInfo.inputLatency = (PaTime) PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* inputLatency is specified in _seconds_ */
+    stream->streamRepresentation.streamInfo.outputLatency = (PaTime) PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor) / sampleRate;       /* outputLatency is specified in _seconds_ */
     stream->streamRepresentation.streamInfo.sampleRate = sampleRate;
 
     stream->maxFramesHostPerBuffer = framesPerBuffer;
     stream->maxFramesPerBuffer = framesPerBuffer;
 
-    *s = (PaStream*)stream;
+    *s = (PaStream *) stream;
 
     pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
     return result;
 
-error:
+  error:
     pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
-    if(stream)
+    if (stream)
     {
         PaUtil_FreeMemory(stream);
         PulseAudioFree(l_ptrPulseAudioHostApi);
@@ -1062,30 +1206,37 @@ error:
     return paNotInitialized;
 }
 
-static PaError IsStreamStopped(PaStream *s)
+static PaError IsStreamStopped(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream *) s;
     return stream->isStopped;
 }
 
 
-static PaError IsStreamActive(PaStream *s)
+static PaError IsStreamActive(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream *) s;
     return stream->isActive;
 }
 
 
-static PaTime GetStreamTime(PaStream *s)
+static PaTime GetStreamTime(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream *) s;
     PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
     pa_usec_t l_lUSec = 0;
     pa_operation *l_ptrOperation;
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
-    if(pa_stream_get_time(stream->outStream, &stream->outStreamTime) !=  -PA_ERR_NODATA)
+    if (pa_stream_get_time(stream->outStream, &stream->outStreamTime) !=
+        -PA_ERR_NODATA)
     {
     }
     else
@@ -1094,14 +1245,15 @@ static PaTime GetStreamTime(PaStream *s)
     }
 
     pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
-    return ((float)stream->outStreamTime / (float)1000000);
+    return ((float) stream->outStreamTime / (float) 1000000);
 }
 
 
-static double GetStreamCpuLoad(PaStream* s)
+static double GetStreamCpuLoad(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream *) s;
 
     return PaUtil_GetCpuLoad(&stream->cpuLoadMeasurer);
 }
-

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -559,10 +559,10 @@ PaError PaPulseAudio_Initialize(
 
     pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
+    memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00,
+           sizeof(PaDeviceInfo) * 1024);
     for (i = 0; i < 1024; i++)
     {
-        memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00,
-               sizeof(PaDeviceInfo) * 1024);
         l_ptrPulseAudioHostApi->pulseaudioDeviceNames[i] = NULL;
     }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -1,6 +1,6 @@
 /*
  * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
- * Pulseaudio host to play natively in Linux based systems without
+ * PulseAudio host to play natively in Linux based systems without
  * ALSA emulation
  *
  * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
@@ -42,9 +42,9 @@
 /** @file
  @ingroup common_src
 
- @brief Pulseaudio implementation of support for a host API.
+ @brief PulseAudio implementation of support for a host API.
 
- This host API implements Pulseaudio support for portaudio
+ This host API implements PulseAudio support for portaudio
  it has callbackmode and normal write mode support
 */
 
@@ -57,16 +57,16 @@
 #include "pa_hostapi_pulseaudio_block.h"
 
 
-/* Pulseaudio headers */
+/* PulseAudio headers */
 #include <stdio.h>
 #include <string.h>
 #include <pulse/pulseaudio.h>
 
-/* This is used to identify process name for Pulseaudio. */
+/* This is used to identify process name for PulseAudio. */
 extern char *__progname;
 
-/* Pulseaudio specific functions */
-int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr)
+/* PulseAudio specific functions */
+int PulseAudioCheckConnection(PaPulseAudioHostApiRepresentation *ptr)
 {
     pa_context_state_t state;
 
@@ -98,14 +98,14 @@ int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr)
     return 0;
 }
 
-PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
+PaPulseAudioHostApiRepresentation *PulseAudioNew(void)
 {
-    PaPulseaudioHostApiRepresentation *ptr;
+    PaPulseAudioHostApiRepresentation *ptr;
     int fd[2] = { -1, -1 };
     char proc[PATH_MAX];
     char buf[PATH_MAX + 20];
 
-    ptr = (PaPulseaudioHostApiRepresentation*)PaUtil_AllocateMemory(sizeof(PaPulseaudioHostApiRepresentation));
+    ptr = (PaPulseAudioHostApiRepresentation*)PaUtil_AllocateMemory(sizeof(PaPulseAudioHostApiRepresentation));
 
     /* prt is NULL if runs out of memory or pointer to allocated memory */
     if (!ptr)
@@ -115,7 +115,7 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
     }
 
     /* Make sure we have NULL all struct first */
-    memset(ptr, 0x00, sizeof(PaPulseaudioHostApiRepresentation));
+    memset(ptr, 0x00, sizeof(PaPulseAudioHostApiRepresentation));
 
     ptr->mainloop = pa_threaded_mainloop_new();
 
@@ -137,7 +137,7 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
         goto fail;
     }
 
-    pa_context_set_state_callback(ptr->context, PulseaudioCheckContextStateCb, ptr);
+    pa_context_set_state_callback(ptr->context, PulseAudioCheckContextStateCb, ptr);
 
 
     if (pa_threaded_mainloop_start(ptr->mainloop) < 0)
@@ -151,11 +151,11 @@ PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
     return ptr;
 
 fail:
-    PulseaudioFree(ptr);
+    PulseAudioFree(ptr);
     return NULL;
 }
 
-void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr)
+void PulseAudioFree(PaPulseAudioHostApiRepresentation *ptr)
 {
     assert(ptr);
 
@@ -188,15 +188,15 @@ void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr)
 }
 
 
-static void PulseaudioCheckContextStateCb(pa_context * c, void *userdata)
+static void PulseAudioCheckContextStateCb(pa_context * c, void *userdata)
 {
-    PaPulseaudioHostApiRepresentation *ptr = userdata;
+    PaPulseAudioHostApiRepresentation *ptr = userdata;
     assert(c);
 
     /* If this is null we have big problems and we probably are out of memory */
     if(!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseaudioCheckContextStateCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioCheckContextStateCb: Out of memory");
         pa_threaded_mainloop_signal(ptr->mainloop, 0);
         return;
     }
@@ -206,9 +206,9 @@ static void PulseaudioCheckContextStateCb(pa_context * c, void *userdata)
 }
 
 
-void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata)
+void PulseAudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata)
 {
-    PaPulseaudioHostApiRepresentation *l_ptrHostApi = (PaPulseaudioHostApiRepresentation *)userdata;
+    PaPulseAudioHostApiRepresentation *l_ptrHostApi = (PaPulseAudioHostApiRepresentation *)userdata;
     PaError result = paNoError;
     char *l_strName = NULL;
 
@@ -217,7 +217,7 @@ void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *u
     /* If this is null we have big problems and we probably are out of memory */
     if(!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseaudioSinkListCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioSinkListCb: Out of memory");
         goto error;
     }
 
@@ -267,9 +267,9 @@ error:
 }
 
 
-void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata)
+void PulseAudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata)
 {
-    PaPulseaudioHostApiRepresentation *l_ptrHostApi = (PaPulseaudioHostApiRepresentation *)userdata;
+    PaPulseAudioHostApiRepresentation *l_ptrHostApi = (PaPulseAudioHostApiRepresentation *)userdata;
     PaError result = paNoError;
     char *l_strName = NULL;
 
@@ -278,7 +278,7 @@ void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, voi
     /* If this is null we have big problems and we probably are out of memory */
     if(!c)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseaudioSourceListCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioSourceListCb: Out of memory");
         goto error;
     }
 
@@ -331,7 +331,7 @@ error:
 }
 
 /* This routine is called whenever the stream state changes */
-void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
+void PulseAudioStreamStateCb(pa_stream *s, void *userdata)
 {
     const pa_buffer_attr *a;
     /* If you need debug pring enable these
@@ -343,11 +343,11 @@ void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
     /* If this is null we have big problems and we probably are out of memory */
     if(!s)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseaudioStreamStateCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioStreamStateCb: Out of memory");
         return;
     }
 
-    /* printf("Portaudio [Pulseaudio (PulseaudioStreamStateCb)]: Stream STATE CHANGED: "); */
+    /* printf("Portaudio [PulseAudio (PulseAudioStreamStateCb)]: Stream STATE CHANGED: "); */
 
     switch (pa_stream_get_state(s))
     {
@@ -360,19 +360,19 @@ void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
     case PA_STREAM_READY:
         /* Mainly here is you need debug printing
 
-          fprintf(stderr, "PulseaudioStreamStateCb: Stream successfully created.\n");
+          fprintf(stderr, "PulseAudioStreamStateCb: Stream successfully created.\n");
 
         if (!(a = pa_stream_get_buffer_attr(s)))
             fprintf(stderr, "pa_stream_get_buffer_attr() failed: %s\n", pa_strerror(pa_context_errno(pa_stream_get_context(s))));
         else {
-                fprintf(stderr, "PulseaudioStreamStateCb: Buffer metrics: maxlength=%u, tlength=%u, prebuf=%u, minreq=%u\n", a->maxlength, a->tlength, a->prebuf, a->minreq);
+                fprintf(stderr, "PulseAudioStreamStateCb: Buffer metrics: maxlength=%u, tlength=%u, prebuf=%u, minreq=%u\n", a->maxlength, a->tlength, a->prebuf, a->minreq);
         }
 
-        fprintf(stderr, "PulseaudioStreamStateCb: Using sample spec '%s', channel map '%s'.\n",
+        fprintf(stderr, "PulseAudioStreamStateCb: Using sample spec '%s', channel map '%s'.\n",
                 pa_sample_spec_snprint(sst, sizeof(sst), pa_stream_get_sample_spec(s)),
                 pa_channel_map_snprint(cmt, sizeof(cmt), pa_stream_get_channel_map(s)));
 
-        fprintf(stderr, "PulseaudioStreamStateCb: Connected to device %s (%u, %ssuspended).\n",
+        fprintf(stderr, "PulseAudioStreamStateCb: Connected to device %s (%u, %ssuspended).\n",
                 pa_stream_get_device_name(s),
                 pa_stream_get_device_index(s),
                 pa_stream_is_suspended(s) ? "" : "not ");*/
@@ -386,16 +386,16 @@ void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
     }
 }
 
-void PulseaudioStreamUnderflowCb(pa_stream *s, void *userdata)
+void PulseAudioStreamUnderflowCb(pa_stream *s, void *userdata)
 {
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)userdata;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)userdata;
 
     assert(s);
 
     /* If this is null we have big problems and we probably are out of memory */
     if(!s)
     {
-        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseaudioStreamUnderflowCb: Out of memory");
+        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0, "PulseAudioStreamUnderflowCb: Out of memory");
         return;
     }
 
@@ -415,50 +415,50 @@ void PulseaudioStreamUnderflowCb(pa_stream *s, void *userdata)
 }
 
 
-PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex)
+PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex)
 {
     PaError result = paNoError;
     int i;
     int deviceCount;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = NULL;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = NULL;
     PaDeviceInfo *deviceInfoArray = NULL;
 
     pa_operation *l_ptrOperation = NULL;
 
-    l_ptrPulseaudioHostApi = PulseaudioNew();
+    l_ptrPulseAudioHostApi = PulseAudioNew();
 
-    if(!l_ptrPulseaudioHostApi)
+    if(!l_ptrPulseAudioHostApi)
     {
         result = paInsufficientMemory;
         goto error;
     }
 
-    l_ptrPulseaudioHostApi->allocations = PaUtil_CreateAllocationGroup();
+    l_ptrPulseAudioHostApi->allocations = PaUtil_CreateAllocationGroup();
 
-    if(!l_ptrPulseaudioHostApi->allocations)
+    if(!l_ptrPulseAudioHostApi->allocations)
     {
-        PulseaudioFree(l_ptrPulseaudioHostApi);
+        PulseAudioFree(l_ptrPulseAudioHostApi);
         result = paInsufficientMemory;
         goto error;
     }
 
-    l_ptrPulseaudioHostApi->hostApiIndex = hostApiIndex;
-    *hostApi = &l_ptrPulseaudioHostApi->inheritedHostApiRep;
+    l_ptrPulseAudioHostApi->hostApiIndex = hostApiIndex;
+    *hostApi = &l_ptrPulseAudioHostApi->inheritedHostApiRep;
     (*hostApi)->info.structVersion = 1;
-    (*hostApi)->info.type = paPulseaudio;
-    (*hostApi)->info.name = "Pulseaudio";
+    (*hostApi)->info.type = paPulseAudio;
+    (*hostApi)->info.name = "PulseAudio";
 
     (*hostApi)->info.defaultInputDevice = paNoDevice;
     (*hostApi)->info.defaultOutputDevice = paNoDevice;
 
     /* Connect to server */
-    pa_context_connect(l_ptrPulseaudioHostApi->context, NULL, 0, NULL);
+    pa_context_connect(l_ptrPulseAudioHostApi->context, NULL, 0, NULL);
 
     while(1)
     {
-        pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+        pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
-        switch (l_ptrPulseaudioHostApi->state)
+        switch (l_ptrPulseAudioHostApi->state)
         {
         case PA_CONTEXT_READY:
             break;
@@ -481,59 +481,59 @@ PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
             break;
         }
 
-        if(l_ptrPulseaudioHostApi->state == PA_CONTEXT_READY)
+        if(l_ptrPulseAudioHostApi->state == PA_CONTEXT_READY)
         {
-            pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
             break;
         }
 
-        pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+        pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
         usleep(100);
     }
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
     for(i = 0; i < 1024; i ++)
     {
-        memset(l_ptrPulseaudioHostApi->deviceInfoArray, 0x00, sizeof(PaDeviceInfo) * 1024);
-        l_ptrPulseaudioHostApi->pulseaudioDeviceNames[i] = NULL;
+        memset(l_ptrPulseAudioHostApi->deviceInfoArray, 0x00, sizeof(PaDeviceInfo) * 1024);
+        l_ptrPulseAudioHostApi->pulseaudioDeviceNames[i] = NULL;
     }
 
-    l_ptrOperation = pa_context_get_sink_info_list(l_ptrPulseaudioHostApi->context,
-                     PulseaudioSinkListCb,
-                     l_ptrPulseaudioHostApi);
+    l_ptrOperation = pa_context_get_sink_info_list(l_ptrPulseAudioHostApi->context,
+                     PulseAudioSinkListCb,
+                     l_ptrPulseAudioHostApi);
 
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
     {
-        pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
     }
 
     pa_operation_unref(l_ptrOperation);
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
-    l_ptrOperation = pa_context_get_source_info_list(l_ptrPulseaudioHostApi->context,
-                     PulseaudioSourceListCb,
-                     l_ptrPulseaudioHostApi);
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
+    l_ptrOperation = pa_context_get_source_info_list(l_ptrPulseAudioHostApi->context,
+                     PulseAudioSourceListCb,
+                     l_ptrPulseAudioHostApi);
 
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
     {
-        pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
     }
 
     pa_operation_unref(l_ptrOperation);
 
-    (*hostApi)->info.deviceCount = l_ptrPulseaudioHostApi->deviceCount;
+    (*hostApi)->info.deviceCount = l_ptrPulseAudioHostApi->deviceCount;
 
-    if(l_ptrPulseaudioHostApi->deviceCount > 0)
+    if(l_ptrPulseAudioHostApi->deviceCount > 0)
     {
         /* If you have over 1024 Audio devices.. shame on you! */
 
         (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
-                                      l_ptrPulseaudioHostApi->allocations, sizeof(PaDeviceInfo*) * l_ptrPulseaudioHostApi->deviceCount);
+                                      l_ptrPulseAudioHostApi->allocations, sizeof(PaDeviceInfo*) * l_ptrPulseAudioHostApi->deviceCount);
 
         if(!(*hostApi)->deviceInfos)
         {
@@ -541,23 +541,23 @@ PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
             goto error;
         }
 
-        for(i = 0; i < l_ptrPulseaudioHostApi->deviceCount; i ++)
+        for(i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i ++)
         {
-            (*hostApi)->deviceInfos[i] = &l_ptrPulseaudioHostApi->deviceInfoArray[i];
+            (*hostApi)->deviceInfos[i] = &l_ptrPulseAudioHostApi->deviceInfoArray[i];
         }
 
         /* First should be the default */
         (*hostApi)->info.defaultInputDevice = -1;
         (*hostApi)->info.defaultOutputDevice = -1;
 
-        for(i = 0; i < l_ptrPulseaudioHostApi->deviceCount; i ++)
+        for(i = 0; i < l_ptrPulseAudioHostApi->deviceCount; i ++)
         {
-            if(l_ptrPulseaudioHostApi->deviceInfoArray[i].maxInputChannels > 0 && (*hostApi)->info.defaultInputDevice == -1)
+            if(l_ptrPulseAudioHostApi->deviceInfoArray[i].maxInputChannels > 0 && (*hostApi)->info.defaultInputDevice == -1)
             {
                 (*hostApi)->info.defaultInputDevice = i;
             }
 
-            if(l_ptrPulseaudioHostApi->deviceInfoArray[i].maxOutputChannels > 0 && (*hostApi)->info.defaultOutputDevice == -1)
+            if(l_ptrPulseAudioHostApi->deviceInfoArray[i].maxOutputChannels > 0 && (*hostApi)->info.defaultOutputDevice == -1)
             {
                 (*hostApi)->info.defaultOutputDevice = i;
             }
@@ -570,11 +570,11 @@ PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
     (*hostApi)->OpenStream = OpenStream;
     (*hostApi)->IsFormatSupported = IsFormatSupported;
 
-    PaUtil_InitializeStreamInterface(&l_ptrPulseaudioHostApi->callbackStreamInterface,
-                                     PulseaudioCloseStreamCb,
-                                     PulseaudioStartStreamCb,
-                                     PulseaudioStopStreamCb,
-                                     PulseaudioAbortStreamCb,
+    PaUtil_InitializeStreamInterface(&l_ptrPulseAudioHostApi->callbackStreamInterface,
+                                     PulseAudioCloseStreamCb,
+                                     PulseAudioStartStreamCb,
+                                     PulseAudioStopStreamCb,
+                                     PulseAudioAbortStreamCb,
                                      IsStreamStopped,
                                      IsStreamActive,
                                      GetStreamTime,
@@ -584,33 +584,33 @@ PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApi
                                      PaUtil_DummyGetReadAvailable,
                                      PaUtil_DummyGetWriteAvailable);
 
-    PaUtil_InitializeStreamInterface(&l_ptrPulseaudioHostApi->blockingStreamInterface,
-                                     PulseaudioCloseStreamCb,
-                                     PulseaudioStartStreamCb,
-                                     PulseaudioStopStreamCb,
-                                     PulseaudioAbortStreamCb,
+    PaUtil_InitializeStreamInterface(&l_ptrPulseAudioHostApi->blockingStreamInterface,
+                                     PulseAudioCloseStreamCb,
+                                     PulseAudioStartStreamCb,
+                                     PulseAudioStopStreamCb,
+                                     PulseAudioAbortStreamCb,
                                      IsStreamStopped,
                                      IsStreamActive,
                                      GetStreamTime,
                                      PaUtil_DummyGetCpuLoad,
-                                     PulseaudioReadStreamBlock,
-                                     PulseaudioWriteStreamBlock,
-                                     PulseaudioGetStreamReadAvailableBlock,
-                                     PulseaudioGetStreamWriteAvailableBlock);
+                                     PulseAudioReadStreamBlock,
+                                     PulseAudioWriteStreamBlock,
+                                     PulseAudioGetStreamReadAvailableBlock,
+                                     PulseAudioGetStreamWriteAvailableBlock);
 
     return result;
 
 error:
 
-    if(l_ptrPulseaudioHostApi)
+    if(l_ptrPulseAudioHostApi)
     {
-        if(l_ptrPulseaudioHostApi->allocations)
+        if(l_ptrPulseAudioHostApi->allocations)
         {
-            PaUtil_FreeAllAllocations(l_ptrPulseaudioHostApi->allocations);
-            PaUtil_DestroyAllocationGroup(l_ptrPulseaudioHostApi->allocations);
+            PaUtil_FreeAllAllocations(l_ptrPulseAudioHostApi->allocations);
+            PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
         }
 
-        PulseaudioFree(l_ptrPulseaudioHostApi);
+        PulseAudioFree(l_ptrPulseAudioHostApi);
     }
 
     return result;
@@ -619,17 +619,17 @@ error:
 
 static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
 {
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = (PaPulseaudioHostApiRepresentation*)hostApi;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = (PaPulseAudioHostApiRepresentation*)hostApi;
 
-    if(l_ptrPulseaudioHostApi->allocations)
+    if(l_ptrPulseAudioHostApi->allocations)
     {
-        PaUtil_FreeAllAllocations(l_ptrPulseaudioHostApi->allocations);
-        PaUtil_DestroyAllocationGroup(l_ptrPulseaudioHostApi->allocations);
+        PaUtil_FreeAllAllocations(l_ptrPulseAudioHostApi->allocations);
+        PaUtil_DestroyAllocationGroup(l_ptrPulseAudioHostApi->allocations);
     }
 
-    pa_context_disconnect(l_ptrPulseaudioHostApi->context);
+    pa_context_disconnect(l_ptrPulseAudioHostApi->context);
 
-    PulseaudioFree(l_ptrPulseaudioHostApi);
+    PulseAudioFree(l_ptrPulseAudioHostApi);
 }
 
 
@@ -747,7 +747,7 @@ static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
     return paFormatIsSupported;
 }
 
-PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
+PaError PulseAudioConvertPortaudioFormatToPulseAudio(PaSampleFormat portaudiosf,
         pa_sample_spec *pulseaudiosf)
 {
     switch(portaudiosf)
@@ -778,7 +778,7 @@ PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
 
     case paCustomFormat:
     case paNonInterleaved:
-        PA_DEBUG(("Pulseaudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n", __FUNCTION__));
+        PA_DEBUG(("PulseAudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n", __FUNCTION__));
         return paNotInitialized;
         break;
     }
@@ -788,7 +788,7 @@ PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
 
 
 /* Allocate buffer. */
-static PaError PulseaudioBlockingInitRingBuffer(PaPulseaudioStream *stream, PaUtilRingBuffer *rbuf, int size)
+static PaError PulseAudioBlockingInitRingBuffer(PaPulseAudioStream *stream, PaUtilRingBuffer *rbuf, int size)
 {
     long l_lNumBytes = 4096 * size;
     char *l_ptrBuffer = (char *) malloc( l_lNumBytes );
@@ -815,8 +815,8 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
                           void *userData)
 {
     PaError result = paNoError;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = (PaPulseaudioHostApiRepresentation*)hostApi;
-    PaPulseaudioStream *stream = NULL;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = (PaPulseAudioHostApiRepresentation*)hostApi;
+    PaPulseAudioStream *stream = NULL;
     unsigned long framesPerHostBuffer = framesPerBuffer; /* these may not be equivalent for all implementations */
     int inputChannelCount, outputChannelCount;
     PaSampleFormat inputSampleFormat, outputSampleFormat;
@@ -829,8 +829,8 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
     }
 
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
-    stream = (PaPulseaudioStream*)PaUtil_AllocateMemory(sizeof(PaPulseaudioStream));
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
+    stream = (PaPulseAudioStream*)PaUtil_AllocateMemory(sizeof(PaPulseAudioStream));
 
     if(!stream)
     {
@@ -882,7 +882,7 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
 
         stream->inputFrameSize = Pa_GetSampleSize(inputSampleFormat) * inputChannelCount;
 
-        PulseaudioConvertPortaudioFormatToPulseaudio(inputSampleFormat, &stream->inSampleSpec);
+        PulseAudioConvertPortaudioFormatToPulseAudio(inputSampleFormat, &stream->inSampleSpec);
         stream->inSampleSpec.rate = sampleRate;
         stream->inSampleSpec.channels = inputChannelCount;
 
@@ -892,13 +892,13 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
             goto error;
         }
 
-        stream->inStream = pa_stream_new(l_ptrPulseaudioHostApi->context, "Portaudio source", &stream->inSampleSpec, NULL);
+        stream->inStream = pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio source", &stream->inSampleSpec, NULL);
 
         if(stream->inStream != NULL)
         {
-            pa_stream_set_state_callback(stream->inStream, PulseaudioStreamStateCb, NULL);
-            pa_stream_set_started_callback(stream->inStream, PulseaudioStreamStartedCb, NULL);
-            pa_stream_set_read_callback(stream->inStream, PulseaudioStreamReadCb, stream);
+            pa_stream_set_state_callback(stream->inStream, PulseAudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->inStream, PulseAudioStreamStartedCb, NULL);
+            pa_stream_set_read_callback(stream->inStream, PulseAudioStreamReadCb, stream);
 
         }
 
@@ -911,7 +911,7 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
 
         if(!streamCallback)
         {
-            PulseaudioBlockingInitRingBuffer(stream, &stream->inputRing, stream->inputFrameSize);
+            PulseAudioBlockingInitRingBuffer(stream, &stream->inputRing, stream->inputFrameSize);
         }
 
     }
@@ -956,7 +956,7 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
 
         stream->outputFrameSize = Pa_GetSampleSize(outputSampleFormat) * outputChannelCount;
 
-        PulseaudioConvertPortaudioFormatToPulseaudio(outputSampleFormat, &stream->outSampleSpec);
+        PulseAudioConvertPortaudioFormatToPulseAudio(outputSampleFormat, &stream->outSampleSpec);
         stream->outSampleSpec.rate = sampleRate;
         stream->outSampleSpec.channels = outputChannelCount;
 
@@ -966,13 +966,13 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
             goto error;
         }
 
-        stream->outStream = pa_stream_new(l_ptrPulseaudioHostApi->context, "Portaudio sink", &stream->outSampleSpec, NULL);
+        stream->outStream = pa_stream_new(l_ptrPulseAudioHostApi->context, "Portaudio sink", &stream->outSampleSpec, NULL);
 
         if(stream->outStream != NULL)
         {
-            pa_stream_set_state_callback(stream->outStream, PulseaudioStreamStateCb, NULL);
-            pa_stream_set_started_callback(stream->outStream, PulseaudioStreamStartedCb, NULL);
-            pa_stream_set_write_callback(stream->outStream, PulseaudioStreamWriteCb, stream);
+            pa_stream_set_state_callback(stream->outStream, PulseAudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->outStream, PulseAudioStreamStartedCb, NULL);
+            pa_stream_set_write_callback(stream->outStream, PulseAudioStreamWriteCb, stream);
         }
 
         else
@@ -983,7 +983,7 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
         if(!streamCallback)
         {
             long l_lnumBytes = 0;
-            if( (l_lnumBytes = PulseaudioBlockingInitRingBuffer(stream, &stream->outputRing, stream->outputFrameSize)) != 0)
+            if( (l_lnumBytes = PulseAudioBlockingInitRingBuffer(stream, &stream->outputRing, stream->outputFrameSize)) != 0)
             {
                 PA_DEBUG(("Portaudio %s: Can't alloc output RingBuffer (Error: %ld)!\n", __FUNCTION__, l_lnumBytes));
                 goto error;
@@ -1001,19 +1001,19 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
     }
 
 
-    stream->hostapi = l_ptrPulseaudioHostApi;
-    stream->context = l_ptrPulseaudioHostApi->context;
-    stream->mainloop = l_ptrPulseaudioHostApi->mainloop;
+    stream->hostapi = l_ptrPulseAudioHostApi;
+    stream->context = l_ptrPulseAudioHostApi->context;
+    stream->mainloop = l_ptrPulseAudioHostApi->mainloop;
 
     if(streamCallback)
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                              &l_ptrPulseaudioHostApi->callbackStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseAudioHostApi->callbackStreamInterface, streamCallback, userData);
     }
     else
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                              &l_ptrPulseaudioHostApi->blockingStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseAudioHostApi->blockingStreamInterface, streamCallback, userData);
     }
 
     PaUtil_InitializeCpuLoadMeasurer(&stream->cpuLoadMeasurer, sampleRate);
@@ -1047,16 +1047,16 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
 
     *s = (PaStream*)stream;
 
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
     return result;
 
 error:
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     if(stream)
     {
         PaUtil_FreeMemory(stream);
-        PulseaudioFree(l_ptrPulseaudioHostApi);
+        PulseAudioFree(l_ptrPulseAudioHostApi);
     }
 
     return paNotInitialized;
@@ -1064,26 +1064,26 @@ error:
 
 static PaError IsStreamStopped(PaStream *s)
 {
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
     return stream->isStopped;
 }
 
 
 static PaError IsStreamActive(PaStream *s)
 {
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
     return stream->isActive;
 }
 
 
 static PaTime GetStreamTime(PaStream *s)
 {
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
     pa_usec_t l_lUSec = 0;
     pa_operation *l_ptrOperation;
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
     if(pa_stream_get_time(stream->outStream, &stream->outStreamTime) !=  -PA_ERR_NODATA)
     {
@@ -1093,14 +1093,14 @@ static PaTime GetStreamTime(PaStream *s)
         stream->outStreamTime = 0;
     }
 
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
     return ((float)stream->outStreamTime / (float)1000000);
 }
 
 
 static double GetStreamCpuLoad(PaStream* s)
 {
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
 
     return PaUtil_GetCpuLoad(&stream->cpuLoadMeasurer);
 }

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -267,9 +267,9 @@ int _PulseAudioAddAudioDevice(
             realName, l_iRealNameLen);
 
     strncpy((char *) hostapi->deviceInfoArray[hostapi->deviceCount].name,
-          interfaceName, l_iDeviceNameLen);
+          interfaceName, (l_iDeviceNameLen - 1));
 
-    l_ptrName = (char *)hostapi->deviceInfoArray[hostapi->deviceCount].name + l_iDeviceNameLen;
+    l_ptrName = (char *)hostapi->deviceInfoArray[hostapi->deviceCount].name + (l_iDeviceNameLen - 1);
     l_ptrName = '\0';
     hostapi->pulseaudioDeviceNames[hostapi->deviceCount][l_iRealNameLen] = '\0';
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -239,14 +239,15 @@ int _PulseAudioAddAudioDevice(
     int l_iRealNameLen = strnlen(realName, 1024) + 1;
     int l_iDeviceNameLen = strnlen(interfaceName, 1024) + 1;
     char *l_ptrName = NULL;
+    char *l_strLocalName = NULL;
     
-    hostapi->pulseaudioDeviceNames[hostapi->deviceCount] = (char *) PaUtil_GroupAllocateMemory(hostapi->allocations,
+    hostapi->pulseaudioDeviceNames[hostapi->deviceCount] = PaUtil_GroupAllocateMemory(hostapi->allocations,
                                                            l_iRealNameLen);
-    hostapi->deviceInfoArray[hostapi->deviceCount].name =  (char *) PaUtil_GroupAllocateMemory(hostapi->allocations,
+    l_strLocalName = PaUtil_GroupAllocateMemory(hostapi->allocations,
                                                            l_iDeviceNameLen);
   
     if( !hostapi->pulseaudioDeviceNames[hostapi->deviceCount] &&
-        !hostapi->deviceInfoArray[hostapi->deviceCount].name)
+        !l_strLocalName)
     {
        PA_PULSEAUDIO_SET_LAST_HOST_ERROR(0,
                                          "Can't alloc memory"); 
@@ -262,14 +263,15 @@ int _PulseAudioAddAudioDevice(
                                                   l_iDeviceNameLen),
               paInsufficientMemory); */
 
-    strncpy((char *)
-            hostapi->pulseaudioDeviceNames[hostapi->deviceCount],
+    strncpy(hostapi->pulseaudioDeviceNames[hostapi->deviceCount],
             realName, l_iRealNameLen);
 
-    strncpy((char *) hostapi->deviceInfoArray[hostapi->deviceCount].name,
+    strncpy(l_strLocalName,
           interfaceName, (l_iDeviceNameLen - 1));
 
-    l_ptrName = (char *)hostapi->deviceInfoArray[hostapi->deviceCount].name + (l_iDeviceNameLen - 1);
+    hostapi->deviceInfoArray[hostapi->deviceCount].name = l_strLocalName;
+
+    l_ptrName = l_strLocalName + (l_iDeviceNameLen - 1);
     l_ptrName = '\0';
     hostapi->pulseaudioDeviceNames[hostapi->deviceCount][l_iRealNameLen] = '\0';
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -68,11 +68,6 @@
 #define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
     PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
 
-/* PaPulseaudioHostApiRepresentation - host api datastructure specific to this implementation */
-
-#define PULSEAUDIO_TIME_EVENT_USEC 50000
-#define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
-
 /* This is used to identify process name for Pulseaudio. */
 extern char *__progname;
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -564,6 +564,7 @@ PaError PaPulseAudio_Initialize(
         l_ptrPulseAudioHostApi->pulseaudioDeviceNames[i] = NULL;
     }
 
+    /* List PulseAudio sinks. If found callback: PulseAudioSinkListCb */
     l_ptrOperation =
         pa_context_get_sink_info_list(l_ptrPulseAudioHostApi->context,
                                       PulseAudioSinkListCb,
@@ -576,6 +577,7 @@ PaError PaPulseAudio_Initialize(
 
     pa_operation_unref(l_ptrOperation);
 
+    /* List PulseAudio sources. If found callback: PulseAudioSourceListCb */
     l_ptrOperation =
         pa_context_get_source_info_list(l_ptrPulseAudioHostApi->context,
                                         PulseAudioSourceListCb,

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -62,12 +62,6 @@
 #include <string.h>
 #include <pulse/pulseaudio.h>
 
-
-/* prototypes for functions declared in this file */
-
-#define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
-    PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
-
 /* This is used to identify process name for Pulseaudio. */
 extern char *__progname;
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -197,13 +197,13 @@ void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *u
     }
 
     PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-               strnlen(l->name, 1024) + 1), paInsufficientMemory);
+              strnlen(l->name, 1024) + 1), paInsufficientMemory);
 
     memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
     strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
 
     PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-               strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+              strnlen(l_strName, 1024) + 1), paInsufficientMemory);
 
     memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
     strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
@@ -251,13 +251,13 @@ void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, voi
     printf("%s Source name: %s (%s)\n", __FUNCTION__, l->name, l->description);
 
     PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-               strnlen(l->name, 1024) + 1), paInsufficientMemory);
+              strnlen(l->name, 1024) + 1), paInsufficientMemory);
 
     memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
     strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
 
     PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
-               strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+              strnlen(l_strName, 1024) + 1), paInsufficientMemory);
 
     memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
     strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
@@ -569,9 +569,9 @@ static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
 
 
 static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
-                                  const PaStreamParameters *inputParameters,
-                                  const PaStreamParameters *outputParameters,
-                                  double sampleRate)
+                                 const PaStreamParameters *inputParameters,
+                                 const PaStreamParameters *outputParameters,
+                                 double sampleRate)
 {
     int inputChannelCount, outputChannelCount;
     PaSampleFormat inputSampleFormat, outputSampleFormat;
@@ -728,8 +728,9 @@ static PaError PulseaudioBlockingInitRingBuffer(PaPulseaudioStream *stream, PaUt
     long l_lNumBytes = 4096 * size;
     char *l_ptrBuffer = (char *) malloc( l_lNumBytes );
 
-    if( l_ptrBuffer == NULL ) {
-       return paInsufficientMemory;
+    if( l_ptrBuffer == NULL )
+    {
+        return paInsufficientMemory;
     }
 
     memset( l_ptrBuffer, 0x00, l_lNumBytes );
@@ -739,14 +740,14 @@ static PaError PulseaudioBlockingInitRingBuffer(PaPulseaudioStream *stream, PaUt
 /* see pa_hostapi.h for a list of validity guarantees made about OpenStream parameters */
 
 static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
-                           PaStream** s,
-                           const PaStreamParameters *inputParameters,
-                           const PaStreamParameters *outputParameters,
-                           double sampleRate,
-                           unsigned long framesPerBuffer,
-                           PaStreamFlags streamFlags,
-                           PaStreamCallback *streamCallback,
-                           void *userData)
+                          PaStream** s,
+                          const PaStreamParameters *inputParameters,
+                          const PaStreamParameters *outputParameters,
+                          double sampleRate,
+                          unsigned long framesPerBuffer,
+                          PaStreamFlags streamFlags,
+                          PaStreamCallback *streamCallback,
+                          void *userData)
 {
     PaError result = paNoError;
     PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = (PaPulseaudioHostApiRepresentation*)hostApi;
@@ -843,10 +844,10 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
 
         stream->device = inputParameters->device;
 
-       if(!streamCallback)
-       {
+        if(!streamCallback)
+        {
             PulseaudioBlockingInitRingBuffer(stream, &stream->inputRing, stream->inputFrameSize);
-       }
+        }
 
     }
 
@@ -919,8 +920,8 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
             long l_lnumBytes = 0;
             if( (l_lnumBytes = PulseaudioBlockingInitRingBuffer(stream, &stream->outputRing, stream->outputFrameSize)) != 0)
             {
-              PA_DEBUG(("Portaudio %s: Can't alloc output RingBuffer (Error: %ld)!\n", __FUNCTION__, l_lnumBytes));
-              goto error;
+                PA_DEBUG(("Portaudio %s: Can't alloc output RingBuffer (Error: %ld)!\n", __FUNCTION__, l_lnumBytes));
+                goto error;
             }
 
         }
@@ -942,12 +943,12 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
     if(streamCallback)
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                               &l_ptrPulseaudioHostApi->callbackStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseaudioHostApi->callbackStreamInterface, streamCallback, userData);
     }
     else
     {
         PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
-                                               &l_ptrPulseaudioHostApi->blockingStreamInterface, streamCallback, userData);
+                                              &l_ptrPulseaudioHostApi->blockingStreamInterface, streamCallback, userData);
     }
 
     PaUtil_InitializeCpuLoadMeasurer(&stream->cpuLoadMeasurer, sampleRate);
@@ -957,7 +958,7 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
         can also support bounded and unknown host buffer sizes by passing
         paUtilBoundedHostBufferSize or paUtilUnknownHostBufferSize instead of
         paUtilFixedHostBufferSize below. */
- 
+
     result =  PaUtil_InitializeBufferProcessor(&stream->bufferProcessor,
               inputChannelCount, inputSampleFormat, hostInputSampleFormat,
               outputChannelCount, outputSampleFormat, hostOutputSampleFormat,
@@ -965,11 +966,11 @@ static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
               framesPerHostBuffer, paUtilUnknownHostBufferSize,
               streamCallback, userData);
 
-     if(result != paNoError)
+    if(result != paNoError)
     {
         goto error;
     }
- 
+
     stream->streamRepresentation.streamInfo.inputLatency =
         (PaTime)PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* inputLatency is specified in _seconds_ */
     stream->streamRepresentation.streamInfo.outputLatency =

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -240,6 +240,9 @@ int _PulseAudioAddAudioDevice(
     int l_iDeviceNameLen = strnlen(PulseAudioSinkSourceName, 1024) + 1;
     char *l_ptrName = NULL;
     char *l_strLocalName = NULL;
+
+    hostapi->deviceInfoArray[hostapi->deviceCount].structVersion = 2;
+    hostapi->deviceInfoArray[hostapi->deviceCount].hostApi = hostapi->hostApiIndex;
     
     hostapi->pulseaudioDeviceNames[hostapi->deviceCount] = PaUtil_GroupAllocateMemory(hostapi->allocations,
                                                            l_iRealNameLen);
@@ -304,10 +307,6 @@ void PulseAudioSinkListCb(
         goto error;
     }
 
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
-        l_ptrHostApi->hostApiIndex;
-
     l_strName = l->name;
 
     if (l->description != NULL)
@@ -358,10 +357,6 @@ void PulseAudioSourceListCb(
     {
         goto error;
     }
-
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
-    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
-        l_ptrHostApi->hostApiIndex;
 
     l_strName = l->name;
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -253,15 +253,6 @@ int _PulseAudioAddAudioDevice(
                                          "Can't alloc memory"); 
        return paInsufficientMemory;
     }
-    /*PA_UNLESS(hostapi->pulseaudioDeviceNames[hostapi->deviceCount] =
-              (char *) PaUtil_GroupAllocateMemory(hostapi->allocations,
-                                                  l_iRealNameLen),
-              paInsufficientMemory);*/
-
-    /* PA_UNLESS(hostapi->deviceInfoArray[hostapi->deviceCount].name =
-              (char *) PaUtil_GroupAllocateMemory(hostapi->allocations,
-                                                  l_iDeviceNameLen),
-              paInsufficientMemory); */
 
     strncpy(hostapi->pulseaudioDeviceNames[hostapi->deviceCount],
             realName, l_iRealNameLen);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -797,31 +797,6 @@ static PaError IsFormatSupported(
         outputChannelCount = 0;
     }
 
-    /*
-     * IMPLEMENT ME:
-     * 
-     * - if a full duplex stream is requested, check that the combination
-     * of input and output parameters is supported if necessary
-     * 
-     * - check that the device supports sampleRate
-     * 
-     * Because the buffer adapter handles conversion between all standard
-     * sample formats, the following checks are only required if paCustomFormat
-     * is implemented, or under some other unusual conditions.
-     * 
-     * - check that input device can support inputSampleFormat, or that
-     * we have the capability to convert from inputSampleFormat to
-     * a native format
-     * 
-     * - check that output device can support outputSampleFormat, or that
-     * we have the capability to convert from outputSampleFormat to
-     * a native format
-     */
-
-
-    /* suppress unused variable warnings */
-    (void) sampleRate;
-
     return paFormatIsSupported;
 }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -849,6 +849,7 @@ static PaError PulseAudioBlockingInitRingBuffer(
         return paInsufficientMemory;
     }
 
+    sem_init(&stream->outputSem, 0, 0);
     memset(l_ptrBuffer, 0x00, l_lNumBytes);
     return (PaError) PaUtil_InitializeRingBuffer(rbuf, 1, l_lNumBytes,
                                                  l_ptrBuffer);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -286,7 +286,7 @@ void PulseAudioSinkListCb(
     PaPulseAudioHostApiRepresentation *l_ptrHostApi =
         (PaPulseAudioHostApiRepresentation *) userdata;
     PaError result = paNoError;
-    char *l_strName = NULL;
+    const char *l_strName = NULL;
 
     assert(c);
 
@@ -308,11 +308,11 @@ void PulseAudioSinkListCb(
     l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
         l_ptrHostApi->hostApiIndex;
 
-    l_strName = (char *) l->name;
+    l_strName = l->name;
 
     if (l->description != NULL)
     {
-        l_strName = (char *) l->description;
+        l_strName = l->description;
     }
 
     _PulseAudioAddAudioDevice(
@@ -341,7 +341,7 @@ void PulseAudioSourceListCb(
     PaPulseAudioHostApiRepresentation *l_ptrHostApi =
         (PaPulseAudioHostApiRepresentation *) userdata;
     PaError result = paNoError;
-    char *l_strName = NULL;
+    const char *l_strName = NULL;
 
     assert(c);
 
@@ -363,11 +363,11 @@ void PulseAudioSourceListCb(
     l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi =
         l_ptrHostApi->hostApiIndex;
 
-    l_strName = (char *) l->name;
+    l_strName = l->name;
 
     if (l->description != NULL)
     {
-        l_strName = (char *) l->description;
+        l_strName = l->description;
     }
 
     _PulseAudioAddAudioDevice(

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -1,0 +1,1040 @@
+/*
+ * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
+ * Pulseaudio host to play natively in Linux based systems without
+ * ALSA emulation
+ *
+ * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2002 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup common_src
+
+ @brief Pulseaudio implementation of support for a host API.
+
+ This host API implements Pulseaudio support for portaudio
+ it has callbackmode and normal write mode support
+*/
+
+
+#include <string.h> /* strlen() */
+
+
+#include "pa_hostapi_pulseaudio.h"
+#include "pa_hostapi_pulseaudio_cb.h"
+#include "pa_hostapi_pulseaudio_block.h"
+
+
+/* Pulseaudio headers */
+#include <stdio.h>
+#include <string.h>
+#include <pulse/pulseaudio.h>
+
+
+/* prototypes for functions declared in this file */
+
+#define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
+    PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
+
+/* PaPulseaudioHostApiRepresentation - host api datastructure specific to this implementation */
+
+#define PULSEAUDIO_TIME_EVENT_USEC 50000
+#define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
+
+/* Pulseaudio specific functions */
+int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr)
+{
+    pa_context_state_t state;
+
+    if (!ptr->context || !ptr->mainloop)
+    {
+        return -1;
+    }
+
+    state = pa_context_get_state(ptr->context);
+
+    if (!PA_CONTEXT_IS_GOOD(state))
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+PaPulseaudioHostApiRepresentation *PulseaudioNew(void)
+{
+    PaPulseaudioHostApiRepresentation *ptr;
+    int fd[2] = { -1, -1 };
+    char proc[PATH_MAX];
+    char buf[PATH_MAX + 20];
+
+    ptr = (PaPulseaudioHostApiRepresentation*)PaUtil_AllocateMemory(sizeof(PaPulseaudioHostApiRepresentation));
+
+    if (!ptr)
+    {
+        return NULL;
+    }
+
+    ptr->mainloop = pa_threaded_mainloop_new();
+
+    if (!ptr->mainloop)
+    {
+        goto fail;
+    }
+
+    memset(buf, 0x00, PATH_MAX + 20);
+    snprintf(buf, sizeof(buf), "Portaudio Pulseaudio HostApi");
+
+    ptr->context =
+        pa_context_new(pa_threaded_mainloop_get_api(ptr->mainloop), buf);
+
+    if (!ptr->context)
+    {
+        goto fail;
+    }
+
+    pa_context_set_state_callback(ptr->context, PulseaudioCheckContextStateCb, ptr);
+
+
+    if (pa_threaded_mainloop_start(ptr->mainloop) < 0)
+    {
+        goto fail;
+    }
+
+    ptr->deviceCount = 0;
+
+    return ptr;
+
+fail:
+    PulseaudioFree(ptr);
+    free(ptr);
+    return NULL;
+}
+
+void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr)
+{
+    if (ptr->mainloop)
+    {
+        pa_threaded_mainloop_stop(ptr->mainloop);
+    }
+
+    if (ptr->context)
+    {
+        pa_context_disconnect(ptr->context);
+        pa_context_unref(ptr->context);
+    }
+
+    if (ptr->mainloop)
+    {
+        pa_threaded_mainloop_free(ptr->mainloop);
+    }
+
+}
+
+
+static void PulseaudioCheckContextStateCb(pa_context * c, void *userdata)
+{
+    PaPulseaudioHostApiRepresentation *ptr = userdata;
+    assert(c);
+
+    ptr->state = pa_context_get_state(c);
+    pa_threaded_mainloop_signal(ptr->mainloop, 0);
+}
+
+
+void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata)
+{
+    PaPulseaudioHostApiRepresentation *l_ptrHostApi = (PaPulseaudioHostApiRepresentation *)userdata;
+    PaError result = paNoError;
+    char *l_strName = NULL;
+
+    /* If eol is set to a positive number, you're at the end of the list */
+    if (eol > 0)
+    {
+        goto error;
+    }
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi = l_ptrHostApi->hostApiIndex;
+
+    l_strName = (char *)l->name;
+
+    if(l->description != NULL)
+    {
+        l_strName = (char *)l->description;
+    }
+
+    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+               strnlen(l->name, 1024) + 1), paInsufficientMemory);
+
+    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
+    strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
+
+    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+               strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+
+    memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
+    strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
+
+    // l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = l->name;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels = 0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels = l->sample_spec.channels;
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowInputLatency = 0.;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowOutputLatency = l->latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighInputLatency = 0.;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighOutputLatency = l->configured_latency;
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate = l->sample_spec.rate;
+
+    l_ptrHostApi->deviceCount ++;
+
+error:
+    pa_threaded_mainloop_signal(l_ptrHostApi->mainloop, 0);
+}
+
+
+void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata)
+{
+    PaPulseaudioHostApiRepresentation *l_ptrHostApi = (PaPulseaudioHostApiRepresentation *)userdata;
+    PaError result = paNoError;
+    char *l_strName = NULL;
+
+    /* If eol is set to a positive number, you're at the end of the list */
+    if (eol > 0)
+    {
+        goto error;
+    }
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].structVersion = 2;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].hostApi = l_ptrHostApi->hostApiIndex;
+
+    l_strName = (char *)l->name;
+
+    if(l->description != NULL)
+    {
+        l_strName = (char *)l->description;
+    }
+
+    printf("%s Source name: %s (%s)\n", __FUNCTION__, l->name, l->description);
+
+    PA_UNLESS(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount] = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+               strnlen(l->name, 1024) + 1), paInsufficientMemory);
+
+    memset(l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], 0x00, strnlen(l->name, 1024) + 1);
+    strncpy((char *)l_ptrHostApi->pulseaudioDeviceNames[l_ptrHostApi->deviceCount], l->name, strnlen(l->name, 1024));
+
+    PA_UNLESS(l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name = (char*)PaUtil_GroupAllocateMemory(l_ptrHostApi->allocations,
+               strnlen(l_strName, 1024) + 1), paInsufficientMemory);
+
+    memset((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, 0x00, strnlen(l_strName, 1024) + 1);
+    strncpy((char *)l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].name, l_strName, strnlen(l_strName, 1024));
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxInputChannels = l->sample_spec.channels;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].maxOutputChannels = 0;
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowInputLatency = (double)l->latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultLowOutputLatency = 0;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighInputLatency = (double)l->configured_latency;
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultHighOutputLatency = 0;
+
+    l_ptrHostApi->deviceInfoArray[l_ptrHostApi->deviceCount].defaultSampleRate = l->sample_spec.rate;
+
+    l_ptrHostApi->deviceCount ++;
+
+error:
+    PA_DEBUG(("Portaudio %s: End of list\n",__FUNCTION__));
+
+    pa_threaded_mainloop_signal(l_ptrHostApi->mainloop, 0);
+}
+
+/* This routine is called whenever the stream state changes */
+void PulseaudioStreamStateCb(pa_stream *s, void *userdata)
+{
+    const pa_buffer_attr *a;
+    char cmt[PA_CHANNEL_MAP_SNPRINT_MAX], sst[PA_SAMPLE_SPEC_SNPRINT_MAX];
+    assert(s);
+
+    /* printf("Portaudio [Pulseaudio (PulseaudioStreamStateCb)]: Stream STATE CHANGED: "); */
+
+    switch (pa_stream_get_state(s))
+    {
+    case PA_STREAM_TERMINATED:
+        /* printf("TERMINATED!\n"); */
+        break;
+
+    case PA_STREAM_CREATING:
+        /* printf("CREATING!\n"); */
+        break;
+
+    case PA_STREAM_READY:
+        /* printf("READY!\n"); */
+
+        /*fprintf(stderr, "PulseaudioStreamStateCb: Stream successfully created.\n");
+
+        if (!(a = pa_stream_get_buffer_attr(s)))
+            fprintf(stderr, "pa_stream_get_buffer_attr() failed: %s\n", pa_strerror(pa_context_errno(pa_stream_get_context(s))));
+        else {
+                fprintf(stderr, "PulseaudioStreamStateCb: Buffer metrics: maxlength=%u, tlength=%u, prebuf=%u, minreq=%u\n", a->maxlength, a->tlength, a->prebuf, a->minreq);
+        }
+
+        fprintf(stderr, "PulseaudioStreamStateCb: Using sample spec '%s', channel map '%s'.\n",
+                pa_sample_spec_snprint(sst, sizeof(sst), pa_stream_get_sample_spec(s)),
+                pa_channel_map_snprint(cmt, sizeof(cmt), pa_stream_get_channel_map(s)));
+
+        fprintf(stderr, "PulseaudioStreamStateCb: Connected to device %s (%u, %ssuspended).\n",
+                pa_stream_get_device_name(s),
+                pa_stream_get_device_index(s),
+                pa_stream_is_suspended(s) ? "" : "not ");*/
+        break;
+
+    case PA_STREAM_FAILED:
+    default:
+        PA_DEBUG(("Portaudio %s: FAILED '%s'\n",__FUNCTION__, pa_strerror(pa_context_errno(pa_stream_get_context(s)))));
+
+        break;
+    }
+}
+
+void PulseaudioStreamUnderflowCb(pa_stream *s, void *userdata)
+{
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)userdata;
+
+    stream->underflows++;
+
+    if (stream->underflows >= 6 && stream->latency < 2000000)
+    {
+        stream->latency = (stream->latency * 3) / 2;
+        stream->bufferAttr.maxlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+        stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+        pa_stream_set_buffer_attr(s, &stream->bufferAttr, NULL, NULL);
+        stream->underflows = 0;
+        PA_DEBUG(("Portaudio %s: latency increased to %d\n", __FUNCTION__, stream->latency));
+    }
+
+    pa_threaded_mainloop_signal(stream->mainloop, 0);
+}
+
+
+PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex)
+{
+    PaError result = paNoError;
+    int i;
+    int deviceCount;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = NULL;
+    PaDeviceInfo *deviceInfoArray = NULL;
+
+    pa_operation *l_ptrOperation = NULL;
+
+    l_ptrPulseaudioHostApi = PulseaudioNew();
+
+    if(!l_ptrPulseaudioHostApi)
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    l_ptrPulseaudioHostApi->allocations = PaUtil_CreateAllocationGroup();
+
+    if(!l_ptrPulseaudioHostApi->allocations)
+    {
+        PulseaudioFree(l_ptrPulseaudioHostApi);
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    l_ptrPulseaudioHostApi->hostApiIndex = hostApiIndex;
+    *hostApi = &l_ptrPulseaudioHostApi->inheritedHostApiRep;
+    (*hostApi)->info.structVersion = 1;
+    (*hostApi)->info.type = paPulseaudio;
+    (*hostApi)->info.name = "Pulseaudio";
+
+    (*hostApi)->info.defaultInputDevice = paNoDevice;
+    (*hostApi)->info.defaultOutputDevice = paNoDevice;
+
+    /* Connect to server */
+    pa_context_connect(l_ptrPulseaudioHostApi->context, NULL, 0, NULL);
+
+    while(1)
+    {
+        pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+        switch (l_ptrPulseaudioHostApi->state)
+        {
+        case PA_CONTEXT_READY:
+            break;
+
+        case PA_CONTEXT_TERMINATED:
+        case PA_CONTEXT_FAILED:
+            goto error;
+            break;
+        case PA_CONTEXT_UNCONNECTED:
+            break;
+
+
+        case PA_CONTEXT_CONNECTING:
+            break;
+
+        case PA_CONTEXT_AUTHORIZING:
+            break;
+
+        case PA_CONTEXT_SETTING_NAME:
+            break;
+        }
+
+        if(l_ptrPulseaudioHostApi->state == PA_CONTEXT_READY)
+        {
+            pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+            break;
+        }
+
+        pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+        usleep(100);
+    }
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+    for(i = 0; i < 1024; i ++)
+    {
+        memset(l_ptrPulseaudioHostApi->deviceInfoArray, 0x00, sizeof(PaDeviceInfo) * 1024);
+        l_ptrPulseaudioHostApi->pulseaudioDeviceNames[i] = NULL;
+    }
+
+    l_ptrOperation = pa_context_get_sink_info_list(l_ptrPulseaudioHostApi->context,
+                     PulseaudioSinkListCb,
+                     l_ptrPulseaudioHostApi);
+
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+    while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
+    {
+        pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+    }
+
+    pa_operation_unref(l_ptrOperation);
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    l_ptrOperation = pa_context_get_source_info_list(l_ptrPulseaudioHostApi->context,
+                     PulseaudioSourceListCb,
+                     l_ptrPulseaudioHostApi);
+
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+    while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
+    {
+        pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+    }
+
+    pa_operation_unref(l_ptrOperation);
+
+    (*hostApi)->info.deviceCount = l_ptrPulseaudioHostApi->deviceCount;
+
+    if(l_ptrPulseaudioHostApi->deviceCount > 0)
+    {
+        /* If you have over 1024 Audio devices.. shame on you! */
+
+        (*hostApi)->deviceInfos = (PaDeviceInfo**)PaUtil_GroupAllocateMemory(
+                                      l_ptrPulseaudioHostApi->allocations, sizeof(PaDeviceInfo*) * l_ptrPulseaudioHostApi->deviceCount);
+
+        if(!(*hostApi)->deviceInfos)
+        {
+            result = paInsufficientMemory;
+            goto error;
+        }
+
+        for(i = 0; i < l_ptrPulseaudioHostApi->deviceCount; i ++)
+        {
+            (*hostApi)->deviceInfos[i] = &l_ptrPulseaudioHostApi->deviceInfoArray[i];
+        }
+
+        /* First should be the default */
+        (*hostApi)->info.defaultInputDevice = -1;
+        (*hostApi)->info.defaultOutputDevice = -1;
+
+        for(i = 0; i < l_ptrPulseaudioHostApi->deviceCount; i ++)
+        {
+            if(l_ptrPulseaudioHostApi->deviceInfoArray[i].maxInputChannels > 0 && (*hostApi)->info.defaultInputDevice == -1)
+            {
+                (*hostApi)->info.defaultInputDevice = i;
+            }
+
+            if(l_ptrPulseaudioHostApi->deviceInfoArray[i].maxOutputChannels > 0 && (*hostApi)->info.defaultOutputDevice == -1)
+            {
+                (*hostApi)->info.defaultOutputDevice = i;
+            }
+        }
+
+
+    }
+
+    (*hostApi)->Terminate = Terminate;
+    (*hostApi)->OpenStream = OpenStream;
+    (*hostApi)->IsFormatSupported = IsFormatSupported;
+
+    PaUtil_InitializeStreamInterface(&l_ptrPulseaudioHostApi->callbackStreamInterface,
+                                     PulseaudioCloseStreamCb,
+                                     PulseaudioStartStreamCb,
+                                     PulseaudioStopStreamCb,
+                                     PulseaudioAbortStreamCb,
+                                     IsStreamStopped,
+                                     IsStreamActive,
+                                     GetStreamTime,
+                                     GetStreamCpuLoad,
+                                     PaUtil_DummyRead,
+                                     PaUtil_DummyWrite,
+                                     PaUtil_DummyGetReadAvailable,
+                                     PaUtil_DummyGetWriteAvailable);
+
+    PaUtil_InitializeStreamInterface(&l_ptrPulseaudioHostApi->blockingStreamInterface,
+                                     PulseaudioCloseStreamCb,
+                                     PulseaudioStartStreamCb,
+                                     PulseaudioStopStreamCb,
+                                     PulseaudioAbortStreamCb,
+                                     IsStreamStopped,
+                                     IsStreamActive,
+                                     GetStreamTime,
+                                     PaUtil_DummyGetCpuLoad,
+                                     PulseaudioReadStreamBlock,
+                                     PulseaudioWriteStreamBlock,
+                                     PulseaudioGetStreamReadAvailableBlock,
+                                     PulseaudioGetStreamWriteAvailableBlock);
+
+    return result;
+
+error:
+
+    if(l_ptrPulseaudioHostApi)
+    {
+        if(l_ptrPulseaudioHostApi->allocations)
+        {
+            PaUtil_FreeAllAllocations(l_ptrPulseaudioHostApi->allocations);
+            PaUtil_DestroyAllocationGroup(l_ptrPulseaudioHostApi->allocations);
+        }
+
+        PaUtil_FreeMemory(l_ptrPulseaudioHostApi);
+    }
+
+    return result;
+}
+
+
+static void Terminate(struct PaUtilHostApiRepresentation *hostApi)
+{
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = (PaPulseaudioHostApiRepresentation*)hostApi;
+
+    if(l_ptrPulseaudioHostApi->allocations)
+    {
+        PaUtil_FreeAllAllocations(l_ptrPulseaudioHostApi->allocations);
+        PaUtil_DestroyAllocationGroup(l_ptrPulseaudioHostApi->allocations);
+    }
+
+    pa_context_disconnect(l_ptrPulseaudioHostApi->context);
+
+    PulseaudioFree(l_ptrPulseaudioHostApi);
+
+    PaUtil_FreeMemory(l_ptrPulseaudioHostApi);
+}
+
+
+static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
+                                  const PaStreamParameters *inputParameters,
+                                  const PaStreamParameters *outputParameters,
+                                  double sampleRate)
+{
+    int inputChannelCount, outputChannelCount;
+    PaSampleFormat inputSampleFormat, outputSampleFormat;
+
+    if(inputParameters)
+    {
+        inputChannelCount = inputParameters->channelCount;
+        inputSampleFormat = inputParameters->sampleFormat;
+
+        /* all standard sample formats are supported by the buffer adapter,
+            this implementation doesn't support any custom sample formats */
+        if(inputSampleFormat & paCustomFormat)
+        {
+            return paSampleFormatNotSupported;
+        }
+
+        /* unless alternate device specification is supported, reject the use of
+            paUseHostApiSpecificDeviceSpecification */
+
+        if(inputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        {
+            return paInvalidDevice;
+        }
+
+        /* check that input device can support inputChannelCount */
+        if(inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels)
+        {
+            return paInvalidChannelCount;
+        }
+
+        /* validate inputStreamInfo */
+        if(inputParameters->hostApiSpecificStreamInfo)
+        {
+            return paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+        }
+
+    }
+
+    else
+    {
+        inputChannelCount = 0;
+    }
+
+    if(outputParameters)
+    {
+        outputChannelCount = outputParameters->channelCount;
+        outputSampleFormat = outputParameters->sampleFormat;
+
+        /* all standard sample formats are supported by the buffer adapter,
+            this implementation doesn't support any custom sample formats */
+        if(outputSampleFormat & paCustomFormat)
+        {
+            return paSampleFormatNotSupported;
+        }
+
+        /* unless alternate device specification is supported, reject the use of
+            paUseHostApiSpecificDeviceSpecification */
+
+        if(outputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        {
+            return paInvalidDevice;
+        }
+
+        /* check that output device can support outputChannelCount */
+        if(outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels)
+        {
+            return paInvalidChannelCount;
+        }
+
+        /* validate outputStreamInfo */
+        if(outputParameters->hostApiSpecificStreamInfo)
+        {
+            return paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+        }
+
+    }
+
+    else
+    {
+        outputChannelCount = 0;
+    }
+
+    /*
+        IMPLEMENT ME:
+
+            - if a full duplex stream is requested, check that the combination
+                of input and output parameters is supported if necessary
+
+            - check that the device supports sampleRate
+
+        Because the buffer adapter handles conversion between all standard
+        sample formats, the following checks are only required if paCustomFormat
+        is implemented, or under some other unusual conditions.
+
+            - check that input device can support inputSampleFormat, or that
+                we have the capability to convert from inputSampleFormat to
+                a native format
+
+            - check that output device can support outputSampleFormat, or that
+                we have the capability to convert from outputSampleFormat to
+                a native format
+    */
+
+
+    /* suppress unused variable warnings */
+    (void) sampleRate;
+
+    return paFormatIsSupported;
+}
+
+PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
+        pa_sample_spec *pulseaudiosf)
+{
+    switch(portaudiosf)
+    {
+    case paFloat32:
+        pulseaudiosf->format = PA_SAMPLE_FLOAT32LE;
+        break;
+
+    case paInt32:
+        pulseaudiosf->format = PA_SAMPLE_S32LE;
+        break;
+
+    case paInt24:
+        pulseaudiosf->format = PA_SAMPLE_S24LE;
+        break;
+
+    case paInt16:
+        pulseaudiosf->format = PA_SAMPLE_S16LE;
+        break;
+
+    case paInt8:
+        pulseaudiosf->format = PA_SAMPLE_U8;
+        break;
+
+    case paUInt8:
+        pulseaudiosf->format = PA_SAMPLE_U8;
+        break;
+
+    case paCustomFormat:
+    case paNonInterleaved:
+        PA_DEBUG(("Pulseaudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n", __FUNCTION__));
+        return paNotInitialized;
+        break;
+    }
+
+    return paNoError;
+}
+
+
+/* Allocate buffer. */
+static PaError PulseaudioBlockingInitRingBuffer(PaPulseaudioStream *stream, PaUtilRingBuffer *rbuf, int size)
+{
+    long l_lNumBytes = 4096 * size;
+    char *l_ptrBuffer = (char *) malloc( l_lNumBytes );
+
+    if( l_ptrBuffer == NULL ) {
+       return paInsufficientMemory;
+    }
+
+    memset( l_ptrBuffer, 0x00, l_lNumBytes );
+    return (PaError) PaUtil_InitializeRingBuffer( rbuf, 1, l_lNumBytes, l_ptrBuffer );
+}
+
+/* see pa_hostapi.h for a list of validity guarantees made about OpenStream parameters */
+
+static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
+                           PaStream** s,
+                           const PaStreamParameters *inputParameters,
+                           const PaStreamParameters *outputParameters,
+                           double sampleRate,
+                           unsigned long framesPerBuffer,
+                           PaStreamFlags streamFlags,
+                           PaStreamCallback *streamCallback,
+                           void *userData)
+{
+    PaError result = paNoError;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = (PaPulseaudioHostApiRepresentation*)hostApi;
+    PaPulseaudioStream *stream = NULL;
+    unsigned long framesPerHostBuffer = framesPerBuffer; /* these may not be equivalent for all implementations */
+    int inputChannelCount, outputChannelCount;
+    PaSampleFormat inputSampleFormat, outputSampleFormat;
+    PaSampleFormat hostInputSampleFormat, hostOutputSampleFormat;
+
+    /* validate platform specific flags */
+    if((streamFlags & paPlatformSpecificFlags) != 0)
+    {
+        return paInvalidFlag;    /* unexpected platform specific flag */
+    }
+
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    stream = (PaPulseaudioStream*)PaUtil_AllocateMemory(sizeof(PaPulseaudioStream));
+
+    if(!stream)
+    {
+        result = paInsufficientMemory;
+        goto error;
+    }
+
+    stream->isActive = 0;
+    stream->isStopped = 1;
+
+    stream->inStream = NULL;
+    stream->outStream = NULL;
+    stream->outBuffer = NULL;
+    stream->inBuffer = NULL;
+    memset(&stream->outputRing, 0x00, sizeof(PaUtilRingBuffer));
+    memset(&stream->inputRing, 0x00, sizeof(PaUtilRingBuffer));
+
+
+    if(inputParameters)
+    {
+        inputChannelCount = inputParameters->channelCount;
+        inputSampleFormat = inputParameters->sampleFormat;
+
+        /* unless alternate device specification is supported, reject the use of
+            paUseHostApiSpecificDeviceSpecification */
+
+        if(inputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        {
+            result = paInvalidDevice;
+            goto error;
+        }
+
+        /* check that input device can support inputChannelCount */
+        if(inputChannelCount > hostApi->deviceInfos[ inputParameters->device ]->maxInputChannels)
+        {
+            result = paInvalidChannelCount;
+            goto error;
+        }
+
+        /* validate inputStreamInfo */
+        if(inputParameters->hostApiSpecificStreamInfo)
+        {
+            result = paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            goto error;
+        }
+
+        hostInputSampleFormat =
+            PaUtil_SelectClosestAvailableFormat(inputSampleFormat, inputSampleFormat);
+
+        stream->inputFrameSize = Pa_GetSampleSize(inputSampleFormat) * inputChannelCount;
+
+        PulseaudioConvertPortaudioFormatToPulseaudio(inputSampleFormat, &stream->inSampleSpec);
+        stream->inSampleSpec.rate = sampleRate;
+        stream->inSampleSpec.channels = inputChannelCount;
+
+        if(!pa_sample_spec_valid(&stream->inSampleSpec   ))
+        {
+            PA_DEBUG(("Portaudio %s: Invalid input audio spec!\n",__FUNCTION__));
+            goto error;
+        }
+
+        stream->inStream = pa_stream_new(l_ptrPulseaudioHostApi->context, "Portaudio source", &stream->inSampleSpec, NULL);
+
+        if(stream->inStream != NULL)
+        {
+            pa_stream_set_state_callback(stream->inStream, PulseaudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->inStream, PulseaudioStreamStartedCb, NULL);
+            pa_stream_set_read_callback(stream->inStream, PulseaudioStreamReadCb, stream);
+
+        }
+
+        else
+        {
+            PA_DEBUG(("Portaudio %s: Can't alloc input stream!\n", __FUNCTION__));
+        }
+
+        stream->device = inputParameters->device;
+
+       if(!streamCallback)
+       {
+            PulseaudioBlockingInitRingBuffer(stream, &stream->inputRing, stream->inputFrameSize);
+       }
+
+    }
+
+    else
+    {
+        inputChannelCount = 0;
+        inputSampleFormat = hostInputSampleFormat = paFloat32;
+    }
+
+    if(outputParameters)
+    {
+        outputChannelCount = outputParameters->channelCount;
+        outputSampleFormat = outputParameters->sampleFormat;
+
+        /* unless alternate device specification is supported, reject the use of
+            paUseHostApiSpecificDeviceSpecification */
+
+        if(outputParameters->device == paUseHostApiSpecificDeviceSpecification)
+        {
+            result = paInvalidDevice;
+            goto error;
+        }
+
+        /* check that output device can support inputChannelCount */
+        if(outputChannelCount > hostApi->deviceInfos[ outputParameters->device ]->maxOutputChannels)
+        {
+            result = paInvalidChannelCount;
+            goto error;
+        }
+
+        /* validate outputStreamInfo */
+        if(outputParameters->hostApiSpecificStreamInfo)
+        {
+            result = paIncompatibleHostApiSpecificStreamInfo;    /* this implementation doesn't use custom stream info */
+            goto error;
+        }
+
+        /* IMPLEMENT ME - establish which  host formats are available */
+        hostOutputSampleFormat =
+            PaUtil_SelectClosestAvailableFormat(outputSampleFormat /* native formats */, outputSampleFormat);
+
+        stream->outputFrameSize = Pa_GetSampleSize(outputSampleFormat) * outputChannelCount;
+
+        PulseaudioConvertPortaudioFormatToPulseaudio(outputSampleFormat, &stream->outSampleSpec);
+        stream->outSampleSpec.rate = sampleRate;
+        stream->outSampleSpec.channels = outputChannelCount;
+
+        if(!pa_sample_spec_valid(&stream->outSampleSpec  ))
+        {
+            PA_DEBUG(("Portaudio %s: Invalid audio spec for output!\n", __FUNCTION__));
+            goto error;
+        }
+
+        stream->outStream = pa_stream_new(l_ptrPulseaudioHostApi->context, "Portaudio sink", &stream->outSampleSpec, NULL);
+
+        if(stream->outStream != NULL)
+        {
+            pa_stream_set_state_callback(stream->outStream, PulseaudioStreamStateCb, NULL);
+            pa_stream_set_started_callback(stream->outStream, PulseaudioStreamStartedCb, NULL);
+            pa_stream_set_write_callback(stream->outStream, PulseaudioStreamWriteCb, stream);
+        }
+
+        else
+        {
+            PA_DEBUG(("Portaudio %s: Can't alloc output stream!\n", __FUNCTION__));
+        }
+
+        if(!streamCallback)
+        {
+            long l_lnumBytes = 0;
+            if( (l_lnumBytes = PulseaudioBlockingInitRingBuffer(stream, &stream->outputRing, stream->outputFrameSize)) != 0)
+            {
+              PA_DEBUG(("Portaudio %s: Can't alloc output RingBuffer (Error: %ld)!\n", __FUNCTION__, l_lnumBytes));
+              goto error;
+            }
+
+        }
+
+        stream->device = outputParameters->device;
+    }
+
+    else
+    {
+        outputChannelCount = 0;
+        outputSampleFormat = hostOutputSampleFormat = paFloat32;
+    }
+
+
+    stream->hostapi = l_ptrPulseaudioHostApi;
+    stream->context = l_ptrPulseaudioHostApi->context;
+    stream->mainloop = l_ptrPulseaudioHostApi->mainloop;
+
+    if(streamCallback)
+    {
+        PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
+                                               &l_ptrPulseaudioHostApi->callbackStreamInterface, streamCallback, userData);
+    }
+    else
+    {
+        PaUtil_InitializeStreamRepresentation(&stream->streamRepresentation,
+                                               &l_ptrPulseaudioHostApi->blockingStreamInterface, streamCallback, userData);
+    }
+
+    PaUtil_InitializeCpuLoadMeasurer(&stream->cpuLoadMeasurer, sampleRate);
+
+
+    /* we assume a fixed host buffer size in this example, but the buffer processor
+        can also support bounded and unknown host buffer sizes by passing
+        paUtilBoundedHostBufferSize or paUtilUnknownHostBufferSize instead of
+        paUtilFixedHostBufferSize below. */
+ 
+    result =  PaUtil_InitializeBufferProcessor(&stream->bufferProcessor,
+              inputChannelCount, inputSampleFormat, hostInputSampleFormat,
+              outputChannelCount, outputSampleFormat, hostOutputSampleFormat,
+              sampleRate, streamFlags, framesPerBuffer,
+              framesPerHostBuffer, paUtilUnknownHostBufferSize,
+              streamCallback, userData);
+
+     if(result != paNoError)
+    {
+        goto error;
+    }
+ 
+    stream->streamRepresentation.streamInfo.inputLatency =
+        (PaTime)PaUtil_GetBufferProcessorInputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* inputLatency is specified in _seconds_ */
+    stream->streamRepresentation.streamInfo.outputLatency =
+        (PaTime)PaUtil_GetBufferProcessorOutputLatencyFrames(&stream->bufferProcessor) / sampleRate; /* outputLatency is specified in _seconds_ */
+    stream->streamRepresentation.streamInfo.sampleRate = sampleRate;
+
+    stream->maxFramesHostPerBuffer = framesPerBuffer;
+    stream->maxFramesPerBuffer = framesPerBuffer;
+
+    *s = (PaStream*)stream;
+
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    return result;
+
+error:
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+    if(stream)
+    {
+        PaUtil_FreeMemory(stream);
+    }
+
+    return paNotInitialized;
+}
+
+static PaError IsStreamStopped(PaStream *s)
+{
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    return stream->isStopped;
+}
+
+
+static PaError IsStreamActive(PaStream *s)
+{
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    return stream->isActive;
+}
+
+
+static PaTime GetStreamTime(PaStream *s)
+{
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    pa_usec_t l_lUSec = 0;
+    pa_operation *l_ptrOperation;
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+    if(pa_stream_get_time(stream->outStream, &stream->outStreamTime) !=  -PA_ERR_NODATA)
+    {
+    }
+    else
+    {
+        stream->outStreamTime = 0;
+    }
+
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    return ((float)stream->outStreamTime / (float)1000000);
+}
+
+
+static double GetStreamCpuLoad(PaStream* s)
+{
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+
+    return PaUtil_GetCpuLoad(&stream->cpuLoadMeasurer);
+}
+

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -12,7 +12,7 @@
 #include "pa_ringbuffer.h"
 #include "pa_debugprint.h"
 
-/* Pulseaudio headers */
+/* PulseAudio headers */
 #include <stdio.h>
 #include <string.h>
 #include <pulse/pulseaudio.h>
@@ -53,23 +53,23 @@ typedef struct
     PaDeviceInfo deviceInfoArray[1024];
     char *pulseaudioDeviceNames[1024];
 
-    /* Pulseaudio stuff goes here */
+    /* PulseAudio stuff goes here */
     pa_threaded_mainloop *mainloop;
     pa_context *context;
     int deviceCount;
     pa_context_state_t state;
     pa_time_event *timeEvent;
 }
-PaPulseaudioHostApiRepresentation;
+PaPulseAudioHostApiRepresentation;
 
-/* PaPulseaudioStream - a stream data structure specifically for this implementation */
+/* PaPulseAudioStream - a stream data structure specifically for this implementation */
 
-typedef struct PaPulseaudioStream
+typedef struct PaPulseAudioStream
 {
     PaUtilStreamRepresentation streamRepresentation;
     PaUtilCpuLoadMeasurer cpuLoadMeasurer;
     PaUtilBufferProcessor bufferProcessor;
-    PaPulseaudioHostApiRepresentation *hostapi;
+    PaPulseAudioHostApiRepresentation *hostapi;
 
     PaUnixThread thread;
     unsigned long framesPerHostCallback;
@@ -108,9 +108,9 @@ typedef struct PaPulseaudioStream
     volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
 
 }
-PaPulseaudioStream;
+PaPulseAudioStream;
 
-PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index);
+PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index);
 
 static void Terminate(struct PaUtilHostApiRepresentation *hostApi);
 
@@ -137,20 +137,20 @@ static PaError IsStreamActive(PaStream *stream);
 static PaTime GetStreamTime(PaStream *stream);
 static double GetStreamCpuLoad(PaStream* stream);
 
-PaPulseaudioHostApiRepresentation *PulseaudioNew(void);
-void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr);
+PaPulseAudioHostApiRepresentation *PulseAudioNew(void);
+void PulseAudioFree(PaPulseAudioHostApiRepresentation *ptr);
 
-int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr);
+int PulseAudioCheckConnection(PaPulseAudioHostApiRepresentation *ptr);
 
-static void PulseaudioCheckContextStateCb(pa_context * c, void *userdata);
-void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
-void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
+static void PulseAudioCheckContextStateCb(pa_context * c, void *userdata);
+void PulseAudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
+void PulseAudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
 
-void PulseaudioStreamStateCb(pa_stream *s, void *userdata);
-void PulseaudioStreamStartedCb(pa_stream *s, void *userdata);
-void PulseaudioStreamUnderflowCb(pa_stream *s, void *userdata);
+void PulseAudioStreamStateCb(pa_stream *s, void *userdata);
+void PulseAudioStreamStartedCb(pa_stream *s, void *userdata);
+void PulseAudioStreamUnderflowCb(pa_stream *s, void *userdata);
 
-PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
+PaError PulseAudioConvertPortaudioFormatToPulseAudio(PaSampleFormat portaudiosf,
         pa_sample_spec *pulseaudiosf);
 
 #ifdef __cplusplus

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -30,8 +30,15 @@ extern "C"
 #define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
     PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
 
-
+/* Just chosen by hand from mistake and success method. Nothing really groudbreaking
+   If there is better number with better explantion then I'll be glad to change this
+   @todo change this to something more sophisticated */
 #define PULSEAUDIO_TIME_EVENT_USEC 50000
+
+/* Assuming of 2 seconds of 44100 Hz sample rate with FLOAT (4 bytes) and stereo channels (2 channels).
+   You should have pretty good size buffer with this. If output/intput doesn't happens in 2 second we
+   have more trouble than this buffer.
+   @todo change this to something more sophisticated */
 #define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
 
 typedef struct

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -23,7 +23,7 @@
 #ifdef __cplusplus
 extern "C"
 {
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
 /* prototypes for functions declared in this file */
 
@@ -41,122 +41,168 @@ extern "C"
    @todo change this to something more sophisticated */
 #define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
 
-typedef struct
-{
-    PaUtilHostApiRepresentation inheritedHostApiRep;
-    PaUtilStreamInterface callbackStreamInterface;
-    PaUtilStreamInterface blockingStreamInterface;
+    typedef struct
+    {
+        PaUtilHostApiRepresentation inheritedHostApiRep;
+        PaUtilStreamInterface callbackStreamInterface;
+        PaUtilStreamInterface blockingStreamInterface;
 
-    PaUtilAllocationGroup *allocations;
+        PaUtilAllocationGroup *allocations;
 
-    PaHostApiIndex hostApiIndex;
-    PaDeviceInfo deviceInfoArray[1024];
-    char *pulseaudioDeviceNames[1024];
+        PaHostApiIndex hostApiIndex;
+        PaDeviceInfo deviceInfoArray[1024];
+        char *pulseaudioDeviceNames[1024];
 
-    /* PulseAudio stuff goes here */
-    pa_threaded_mainloop *mainloop;
-    pa_context *context;
-    int deviceCount;
-    pa_context_state_t state;
-    pa_time_event *timeEvent;
-}
-PaPulseAudioHostApiRepresentation;
+        /* PulseAudio stuff goes here */
+        pa_threaded_mainloop *mainloop;
+        pa_context *context;
+        int deviceCount;
+        pa_context_state_t state;
+        pa_time_event *timeEvent;
+    }
+    PaPulseAudioHostApiRepresentation;
 
 /* PaPulseAudioStream - a stream data structure specifically for this implementation */
 
-typedef struct PaPulseAudioStream
-{
-    PaUtilStreamRepresentation streamRepresentation;
-    PaUtilCpuLoadMeasurer cpuLoadMeasurer;
-    PaUtilBufferProcessor bufferProcessor;
-    PaPulseAudioHostApiRepresentation *hostapi;
+    typedef struct PaPulseAudioStream
+    {
+        PaUtilStreamRepresentation streamRepresentation;
+        PaUtilCpuLoadMeasurer cpuLoadMeasurer;
+        PaUtilBufferProcessor bufferProcessor;
+        PaPulseAudioHostApiRepresentation *hostapi;
 
-    PaUnixThread thread;
-    unsigned long framesPerHostCallback;
-    pa_threaded_mainloop *mainloop;
-    pa_simple *simple;
-    pa_context *context;
-    pa_sample_spec outSampleSpec;
-    pa_sample_spec inSampleSpec;
-    pa_stream *outStream;
-    pa_stream *inStream;
-    size_t writableSize;
-    pa_usec_t outStreamTime;
-    pa_buffer_attr bufferAttr;
-    int underflows;
-    int latency;
+        PaUnixThread thread;
+        unsigned long framesPerHostCallback;
+        pa_threaded_mainloop *mainloop;
+        pa_simple *simple;
+        pa_context *context;
+        pa_sample_spec outSampleSpec;
+        pa_sample_spec inSampleSpec;
+        pa_stream *outStream;
+        pa_stream *inStream;
+        size_t writableSize;
+        pa_usec_t outStreamTime;
+        pa_buffer_attr bufferAttr;
+        int underflows;
+        int latency;
 
-    int callbackMode;              /* bool: are we running in callback mode? */
-    int rtSched;
-    long maxFramesPerBuffer;
-    long maxFramesHostPerBuffer;
-    int outputFrameSize;
-    int inputFrameSize;
+        int callbackMode;       /* bool: are we running in callback mode? */
+        int rtSched;
+        long maxFramesPerBuffer;
+        long maxFramesHostPerBuffer;
+        int outputFrameSize;
+        int inputFrameSize;
 
-    PaDeviceIndex device;
+        PaDeviceIndex device;
 
-    void *outBuffer;
-    void *inBuffer;
+        void *outBuffer;
+        void *inBuffer;
 
-    PaUtilRingBuffer        inputRing;
-    PaUtilRingBuffer        outputRing;
+        PaUtilRingBuffer inputRing;
+        PaUtilRingBuffer outputRing;
 
-    /* Used in communication between threads */
-    volatile sig_atomic_t callback_finished; /* bool: are we in the "callback finished" state? */
-    volatile sig_atomic_t callbackAbort;    /* Drop frames? */
-    volatile sig_atomic_t isActive;         /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
-    volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+        /* Used in communication between threads */
+        volatile sig_atomic_t callback_finished;        /* bool: are we in the "callback finished" state? */
+        volatile sig_atomic_t callbackAbort;    /* Drop frames? */
+        volatile sig_atomic_t isActive; /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+        volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
 
-}
-PaPulseAudioStream;
+    }
+    PaPulseAudioStream;
 
-PaError PaPulseAudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index);
+    PaError PaPulseAudio_Initialize(
+    PaUtilHostApiRepresentation ** hostApi,
+    PaHostApiIndex index
+    );
 
-static void Terminate(struct PaUtilHostApiRepresentation *hostApi);
-
-
-static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
-                                 const PaStreamParameters *inputParameters,
-                                 const PaStreamParameters *outputParameters,
-                                 double sampleRate);
-
-static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
-                          PaStream** s,
-                          const PaStreamParameters *inputParameters,
-                          const PaStreamParameters *outputParameters,
-                          double sampleRate,
-                          unsigned long framesPerBuffer,
-                          PaStreamFlags streamFlags,
-                          PaStreamCallback *streamCallback,
-                          void *userData);
+    static void Terminate(
+    struct PaUtilHostApiRepresentation *hostApi
+    );
 
 
-static PaError IsStreamStopped(PaStream *s);
-static PaError IsStreamActive(PaStream *stream);
+    static PaError IsFormatSupported(
+    struct PaUtilHostApiRepresentation *hostApi,
+    const PaStreamParameters * inputParameters,
+    const PaStreamParameters * outputParameters,
+    double sampleRate
+    );
 
-static PaTime GetStreamTime(PaStream *stream);
-static double GetStreamCpuLoad(PaStream* stream);
+    static PaError OpenStream(
+    struct PaUtilHostApiRepresentation *hostApi,
+    PaStream ** s,
+    const PaStreamParameters * inputParameters,
+    const PaStreamParameters * outputParameters,
+    double sampleRate,
+    unsigned long framesPerBuffer,
+    PaStreamFlags streamFlags,
+    PaStreamCallback * streamCallback,
+    void *userData
+    );
 
-PaPulseAudioHostApiRepresentation *PulseAudioNew(void);
-void PulseAudioFree(PaPulseAudioHostApiRepresentation *ptr);
 
-int PulseAudioCheckConnection(PaPulseAudioHostApiRepresentation *ptr);
+    static PaError IsStreamStopped(
+    PaStream * s
+    );
+    static PaError IsStreamActive(
+    PaStream * stream
+    );
 
-static void PulseAudioCheckContextStateCb(pa_context * c, void *userdata);
-void PulseAudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
-void PulseAudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
+    static PaTime GetStreamTime(
+    PaStream * stream
+    );
+    static double GetStreamCpuLoad(
+    PaStream * stream
+    );
 
-void PulseAudioStreamStateCb(pa_stream *s, void *userdata);
-void PulseAudioStreamStartedCb(pa_stream *s, void *userdata);
-void PulseAudioStreamUnderflowCb(pa_stream *s, void *userdata);
+    PaPulseAudioHostApiRepresentation *PulseAudioNew(
+    void
+    );
+    void PulseAudioFree(
+    PaPulseAudioHostApiRepresentation * ptr
+    );
 
-PaError PulseAudioConvertPortaudioFormatToPulseAudio(PaSampleFormat portaudiosf,
-        pa_sample_spec *pulseaudiosf);
+    int PulseAudioCheckConnection(
+    PaPulseAudioHostApiRepresentation * ptr
+    );
+
+    static void PulseAudioCheckContextStateCb(
+    pa_context * c,
+    void *userdata
+    );
+    void PulseAudioSinkListCb(
+    pa_context * c,
+    const pa_sink_info * l,
+    int eol,
+    void *userdata
+    );
+    void PulseAudioSourceListCb(
+    pa_context * c,
+    const pa_source_info * l,
+    int eol,
+    void *userdata
+    );
+
+    void PulseAudioStreamStateCb(
+    pa_stream * s,
+    void *userdata
+    );
+    void PulseAudioStreamStartedCb(
+    pa_stream * s,
+    void *userdata
+    );
+    void PulseAudioStreamUnderflowCb(
+    pa_stream * s,
+    void *userdata
+    );
+
+    PaError PulseAudioConvertPortaudioFormatToPulseAudio(
+    PaSampleFormat portaudiosf,
+    pa_sample_spec * pulseaudiosf
+    );
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
 
 #endif
-

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -18,7 +18,7 @@
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
 
-
+#include <semaphore.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -100,12 +100,14 @@ extern "C"
 
         PaUtilRingBuffer inputRing;
         PaUtilRingBuffer outputRing;
+        sem_t            outputSem;
 
         /* Used in communication between threads */
         volatile sig_atomic_t callback_finished;        /* bool: are we in the "callback finished" state? */
         volatile sig_atomic_t callbackAbort;    /* Drop frames? */
         volatile sig_atomic_t isActive; /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
         volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+        volatile sig_atomic_t outputFull;       /* is WriteStream blocked waiting for space in the ring buffer? */
 
     }
     PaPulseAudioStream;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -109,19 +109,19 @@ static void Terminate(struct PaUtilHostApiRepresentation *hostApi);
 
 
 static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
-                                  const PaStreamParameters *inputParameters,
-                                  const PaStreamParameters *outputParameters,
-                                  double sampleRate);
+                                 const PaStreamParameters *inputParameters,
+                                 const PaStreamParameters *outputParameters,
+                                 double sampleRate);
 
 static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
-                           PaStream** s,
-                           const PaStreamParameters *inputParameters,
-                           const PaStreamParameters *outputParameters,
-                           double sampleRate,
-                           unsigned long framesPerBuffer,
-                           PaStreamFlags streamFlags,
-                           PaStreamCallback *streamCallback,
-                           void *userData);
+                          PaStream** s,
+                          const PaStreamParameters *inputParameters,
+                          const PaStreamParameters *outputParameters,
+                          double sampleRate,
+                          unsigned long framesPerBuffer,
+                          PaStreamFlags streamFlags,
+                          PaStreamCallback *streamCallback,
+                          void *userData);
 
 
 static PaError IsStreamStopped(PaStream *s);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -1,0 +1,155 @@
+#ifndef _PA_HOSTAPI_PULSEAUDIO_H_
+#define _PA_HOSTAPI_PULSEAUDIO_H_
+
+#include "pa_util.h"
+#include "pa_allocation.h"
+#include "pa_hostapi.h"
+#include "pa_stream.h"
+#include "pa_cpuload.h"
+#include "pa_process.h"
+
+#include "pa_unix_util.h"
+#include "pa_ringbuffer.h"
+#include "pa_debugprint.h"
+
+/* Pulseaudio headers */
+#include <stdio.h>
+#include <string.h>
+#include <pulse/pulseaudio.h>
+#include <pulse/simple.h>
+
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+/* prototypes for functions declared in this file */
+
+#define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
+    PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
+
+
+#define PULSEAUDIO_TIME_EVENT_USEC 50000
+#define PULSEAUDIO_BUFFER_SIZE (88100 * 4 * 2)
+
+typedef struct
+{
+    PaUtilHostApiRepresentation inheritedHostApiRep;
+    PaUtilStreamInterface callbackStreamInterface;
+    PaUtilStreamInterface blockingStreamInterface;
+
+    PaUtilAllocationGroup *allocations;
+
+    PaHostApiIndex hostApiIndex;
+    PaDeviceInfo deviceInfoArray[1024];
+    char *pulseaudioDeviceNames[1024];
+
+    /* Pulseaudio stuff goes here */
+    pa_threaded_mainloop *mainloop;
+    pa_context *context;
+    int deviceCount;
+    pa_context_state_t state;
+    pa_time_event *timeEvent;
+}
+PaPulseaudioHostApiRepresentation;
+
+/* PaPulseaudioStream - a stream data structure specifically for this implementation */
+
+typedef struct PaPulseaudioStream
+{
+    PaUtilStreamRepresentation streamRepresentation;
+    PaUtilCpuLoadMeasurer cpuLoadMeasurer;
+    PaUtilBufferProcessor bufferProcessor;
+    PaPulseaudioHostApiRepresentation *hostapi;
+
+    PaUnixThread thread;
+    unsigned long framesPerHostCallback;
+    pa_threaded_mainloop *mainloop;
+    pa_simple *simple;
+    pa_context *context;
+    pa_sample_spec outSampleSpec;
+    pa_sample_spec inSampleSpec;
+    pa_stream *outStream;
+    pa_stream *inStream;
+    size_t writableSize;
+    pa_usec_t outStreamTime;
+    pa_buffer_attr bufferAttr;
+    int underflows;
+    int latency;
+
+    int callbackMode;              /* bool: are we running in callback mode? */
+    int rtSched;
+    long maxFramesPerBuffer;
+    long maxFramesHostPerBuffer;
+    int outputFrameSize;
+    int inputFrameSize;
+
+    PaDeviceIndex device;
+
+    void *outBuffer;
+    void *inBuffer;
+
+    PaUtilRingBuffer        inputRing;
+    PaUtilRingBuffer        outputRing;
+
+    /* Used in communication between threads */
+    volatile sig_atomic_t callback_finished; /* bool: are we in the "callback finished" state? */
+    volatile sig_atomic_t callbackAbort;    /* Drop frames? */
+    volatile sig_atomic_t isActive;         /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+    volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+
+}
+PaPulseaudioStream;
+
+PaError PaPulseaudio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index);
+
+static void Terminate(struct PaUtilHostApiRepresentation *hostApi);
+
+
+static PaError IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
+                                  const PaStreamParameters *inputParameters,
+                                  const PaStreamParameters *outputParameters,
+                                  double sampleRate);
+
+static PaError OpenStream(struct PaUtilHostApiRepresentation *hostApi,
+                           PaStream** s,
+                           const PaStreamParameters *inputParameters,
+                           const PaStreamParameters *outputParameters,
+                           double sampleRate,
+                           unsigned long framesPerBuffer,
+                           PaStreamFlags streamFlags,
+                           PaStreamCallback *streamCallback,
+                           void *userData);
+
+
+static PaError IsStreamStopped(PaStream *s);
+static PaError IsStreamActive(PaStream *stream);
+
+static PaTime GetStreamTime(PaStream *stream);
+static double GetStreamCpuLoad(PaStream* stream);
+
+PaPulseaudioHostApiRepresentation *PulseaudioNew(void);
+void PulseaudioFree(PaPulseaudioHostApiRepresentation *ptr);
+
+int PulseaudioCheckConnection(PaPulseaudioHostApiRepresentation *ptr);
+
+static void PulseaudioCheckContextStateCb(pa_context * c, void *userdata);
+void PulseaudioSinkListCb(pa_context *c, const pa_sink_info *l, int eol, void *userdata);
+void PulseaudioSourceListCb(pa_context *c, const pa_source_info *l, int eol, void *userdata);
+
+void PulseaudioStreamStateCb(pa_stream *s, void *userdata);
+void PulseaudioStreamStartedCb(pa_stream *s, void *userdata);
+void PulseaudioStreamUnderflowCb(pa_stream *s, void *userdata);
+
+PaError PulseaudioConvertPortaudioFormatToPulseaudio(PaSampleFormat portaudiosf,
+        pa_sample_spec *pulseaudiosf);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+
+#endif
+

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
@@ -1,6 +1,6 @@
 /*
  * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
- * Pulseaudio host to play natively in Linux based systems without
+ * PulseAudio host to play natively in Linux based systems without
  * ALSA emulation
  *
  * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
@@ -42,9 +42,9 @@
 /** @file
  @ingroup common_src
 
- @brief Pulseaudio implementation of support for a host API.
+ @brief PulseAudio implementation of support for a host API.
 
- This host API implements Pulseaudio support for portaudio
+ This host API implements PulseAudio support for portaudio
  it has callbackmode and normal write mode support
 */
 
@@ -56,12 +56,12 @@
     for blocking streams.
 */
 
-PaError PulseaudioReadStreamBlock(PaStream* s,
+PaError PulseAudioReadStreamBlock(PaStream* s,
                                   void *buffer,
                                   unsigned long frames)
 {
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
     PaError l_iRet = 0;
     size_t l_lReadable = 0;
     uint8_t *l_ptrData = (uint8_t*)buffer;
@@ -94,13 +94,13 @@ PaError PulseaudioReadStreamBlock(PaStream* s,
 }
 
 
-PaError PulseaudioWriteStreamBlock(PaStream* s,
+PaError PulseAudioWriteStreamBlock(PaStream* s,
                                    const void *buffer,
                                    unsigned long frames)
 {
 
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
     PaError l_iRet = 0;
     size_t l_lWritable = 0;
     uint8_t *l_ptrData = (uint8_t*)buffer;
@@ -135,9 +135,9 @@ PaError PulseaudioWriteStreamBlock(PaStream* s,
 }
 
 
-signed long PulseaudioGetStreamReadAvailableBlock(PaStream* s)
+signed long PulseAudioGetStreamReadAvailableBlock(PaStream* s)
 {
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
 
     if(l_ptrStream->inStream ==  NULL)
     {
@@ -148,10 +148,10 @@ signed long PulseaudioGetStreamReadAvailableBlock(PaStream* s)
 }
 
 
-signed long PulseaudioGetStreamWriteAvailableBlock(PaStream* s)
+signed long PulseAudioGetStreamWriteAvailableBlock(PaStream* s)
 {
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
 
     if(l_ptrStream->outStream ==  NULL)
     {

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
@@ -1,3 +1,4 @@
+
 /*
  * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
  * PulseAudio host to play natively in Linux based systems without
@@ -56,15 +57,18 @@
     for blocking streams.
 */
 
-PaError PulseAudioReadStreamBlock(PaStream* s,
-                                  void *buffer,
-                                  unsigned long frames)
+PaError PulseAudioReadStreamBlock(
+    PaStream * s,
+    void *buffer,
+    unsigned long frames
+)
 {
-    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
-    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi =
+        l_ptrStream->hostapi;
     PaError l_iRet = 0;
     size_t l_lReadable = 0;
-    uint8_t *l_ptrData = (uint8_t*)buffer;
+    uint8_t *l_ptrData = (uint8_t *) buffer;
     long l_lLength = (frames * l_ptrStream->inputFrameSize);
 
     pa_threaded_mainloop_lock(l_ptrStream->mainloop);
@@ -73,15 +77,21 @@ PaError PulseAudioReadStreamBlock(PaStream* s,
 
     while (l_lLength > 0)
     {
-        if( PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) > l_lLength)
+        if (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) >
+            l_lLength)
         {
-            l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lLength);
+            l_iRet =
+                PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData,
+                                      l_lLength);
             l_lLength = 0;
         }
         else
         {
-            l_lReadable = PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
-            l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lReadable);
+            l_lReadable =
+                PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
+            l_iRet =
+                PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData,
+                                      l_lReadable);
             l_ptrData += l_lReadable;
             l_lLength -= l_lReadable;
         }
@@ -94,35 +104,47 @@ PaError PulseAudioReadStreamBlock(PaStream* s,
 }
 
 
-PaError PulseAudioWriteStreamBlock(PaStream* s,
-                                   const void *buffer,
-                                   unsigned long frames)
+PaError PulseAudioWriteStreamBlock(
+    PaStream * s,
+    const void *buffer,
+    unsigned long frames
+)
 {
 
-    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
-    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi =
+        l_ptrStream->hostapi;
     PaError l_iRet = 0;
     size_t l_lWritable = 0;
-    uint8_t *l_ptrData = (uint8_t*)buffer;
+    uint8_t *l_ptrData = (uint8_t *) buffer;
     long l_lLength = (frames * l_ptrStream->outputFrameSize);
 
     pa_threaded_mainloop_lock(l_ptrStream->mainloop);
 
     l_lLength -= PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
     l_ptrData += PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
-    l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, buffer, PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing));
+    l_iRet =
+        PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, buffer,
+                               PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->
+                                                                  outputRing));
 
     while (l_lLength > 0)
     {
-        if( PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing) > l_lLength)
+        if (PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing) >
+            l_lLength)
         {
-            l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lLength);
+            l_iRet =
+                PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData,
+                                       l_lLength);
             l_lLength = 0;
         }
         else
         {
-            l_lWritable = PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
-            l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lWritable);
+            l_lWritable =
+                PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
+            l_iRet =
+                PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData,
+                                       l_lWritable);
             l_ptrData += l_lWritable;
             l_lLength -= l_lWritable;
         }
@@ -135,31 +157,35 @@ PaError PulseAudioWriteStreamBlock(PaStream* s,
 }
 
 
-signed long PulseAudioGetStreamReadAvailableBlock(PaStream* s)
+signed long PulseAudioGetStreamReadAvailableBlock(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) s;
 
-    if(l_ptrStream->inStream ==  NULL)
+    if (l_ptrStream->inStream == NULL)
     {
         return 0;
     }
 
-    return (PaUtil_GetRingBufferReadAvailable( &l_ptrStream->inputRing ) / l_ptrStream->inputFrameSize);
+    return (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) /
+            l_ptrStream->inputFrameSize);
 }
 
 
-signed long PulseAudioGetStreamWriteAvailableBlock(PaStream* s)
+signed long PulseAudioGetStreamWriteAvailableBlock(
+    PaStream * s
+)
 {
-    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream*)s;
-    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = l_ptrStream->hostapi;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi =
+        l_ptrStream->hostapi;
 
-    if(l_ptrStream->outStream ==  NULL)
+    if (l_ptrStream->outStream == NULL)
     {
         return 0;
     }
 
-    return (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing) / l_ptrStream->outputFrameSize);
+    return (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing) /
+            l_ptrStream->outputFrameSize);
 }
-
-
-

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
@@ -57,8 +57,8 @@
 */
 
 PaError PulseaudioReadStreamBlock(PaStream* s,
-                           void *buffer,
-                           unsigned long frames)
+                                  void *buffer,
+                                  unsigned long frames)
 {
     PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
     PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
@@ -71,31 +71,32 @@ PaError PulseaudioReadStreamBlock(PaStream* s,
 
 
 
-    while (l_lLength > 0) {
+    while (l_lLength > 0)
+    {
         if( PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) > l_lLength)
         {
-          l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lLength);
-          l_lLength = 0;
+            l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lLength);
+            l_lLength = 0;
         }
         else
         {
-          l_lReadable = PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
-          l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lReadable);
-          l_ptrData += l_lReadable;
-          l_lLength -= l_lReadable;
+            l_lReadable = PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
+            l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lReadable);
+            l_ptrData += l_lReadable;
+            l_lLength -= l_lReadable;
         }
-      
+
         pa_threaded_mainloop_wait(l_ptrStream->mainloop);
     }
 
     pa_threaded_mainloop_unlock(l_ptrStream->mainloop);
-return paNoError;
+    return paNoError;
 }
 
 
 PaError PulseaudioWriteStreamBlock(PaStream* s,
-                            const void *buffer,
-                            unsigned long frames)
+                                   const void *buffer,
+                                   unsigned long frames)
 {
 
     PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
@@ -111,20 +112,21 @@ PaError PulseaudioWriteStreamBlock(PaStream* s,
     l_ptrData += PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
     l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, buffer, PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing));
 
-    while (l_lLength > 0) {
+    while (l_lLength > 0)
+    {
         if( PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing) > l_lLength)
         {
-          l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lLength);
-          l_lLength = 0;
+            l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lLength);
+            l_lLength = 0;
         }
         else
         {
-          l_lWritable = PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
-          l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lWritable);
-          l_ptrData += l_lWritable;
-          l_lLength -= l_lWritable;
+            l_lWritable = PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
+            l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lWritable);
+            l_ptrData += l_lWritable;
+            l_lLength -= l_lWritable;
         }
-      
+
         pa_threaded_mainloop_wait(l_ptrStream->mainloop);
     }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
@@ -1,0 +1,163 @@
+/*
+ * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
+ * Pulseaudio host to play natively in Linux based systems without
+ * ALSA emulation
+ *
+ * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2002 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup common_src
+
+ @brief Pulseaudio implementation of support for a host API.
+
+ This host API implements Pulseaudio support for portaudio
+ it has callbackmode and normal write mode support
+*/
+
+#include "pa_hostapi_pulseaudio_block.h"
+
+/*
+    As separate stream interfaces are used for blocking and callback
+    streams, the following functions can be guaranteed to only be called
+    for blocking streams.
+*/
+
+PaError PulseaudioReadStreamBlock(PaStream* s,
+                           void *buffer,
+                           unsigned long frames)
+{
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+    PaError l_iRet = 0;
+    size_t l_lReadable = 0;
+    uint8_t *l_ptrData = (uint8_t*)buffer;
+    long l_lLength = (frames * l_ptrStream->inputFrameSize);
+
+    pa_threaded_mainloop_lock(l_ptrStream->mainloop);
+
+
+
+    while (l_lLength > 0) {
+        if( PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) > l_lLength)
+        {
+          l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lLength);
+          l_lLength = 0;
+        }
+        else
+        {
+          l_lReadable = PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
+          l_iRet = PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData, l_lReadable);
+          l_ptrData += l_lReadable;
+          l_lLength -= l_lReadable;
+        }
+      
+        pa_threaded_mainloop_wait(l_ptrStream->mainloop);
+    }
+
+    pa_threaded_mainloop_unlock(l_ptrStream->mainloop);
+return paNoError;
+}
+
+
+PaError PulseaudioWriteStreamBlock(PaStream* s,
+                            const void *buffer,
+                            unsigned long frames)
+{
+
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+    PaError l_iRet = 0;
+    size_t l_lWritable = 0;
+    uint8_t *l_ptrData = (uint8_t*)buffer;
+    long l_lLength = (frames * l_ptrStream->outputFrameSize);
+
+    pa_threaded_mainloop_lock(l_ptrStream->mainloop);
+
+    l_lLength -= PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
+    l_ptrData += PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
+    l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, buffer, PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing));
+
+    while (l_lLength > 0) {
+        if( PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing) > l_lLength)
+        {
+          l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lLength);
+          l_lLength = 0;
+        }
+        else
+        {
+          l_lWritable = PaUtil_GetRingBufferWriteAvailable(&l_ptrStream->outputRing);
+          l_iRet = PaUtil_WriteRingBuffer(&l_ptrStream->outputRing, l_ptrData, l_lWritable);
+          l_ptrData += l_lWritable;
+          l_lLength -= l_lWritable;
+        }
+      
+        pa_threaded_mainloop_wait(l_ptrStream->mainloop);
+    }
+
+    pa_threaded_mainloop_unlock(l_ptrStream->mainloop);
+    return paNoError;
+}
+
+
+signed long PulseaudioGetStreamReadAvailableBlock(PaStream* s)
+{
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
+
+    if(l_ptrStream->inStream ==  NULL)
+    {
+        return 0;
+    }
+
+    return (PaUtil_GetRingBufferReadAvailable( &l_ptrStream->inputRing ) / l_ptrStream->inputFrameSize);
+}
+
+
+signed long PulseaudioGetStreamWriteAvailableBlock(PaStream* s)
+{
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream*)s;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = l_ptrStream->hostapi;
+
+    if(l_ptrStream->outStream ==  NULL)
+    {
+        return 0;
+    }
+
+    return (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing) / l_ptrStream->outputFrameSize);
+}
+
+
+

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
@@ -21,21 +21,40 @@
 #ifdef __cplusplus
 extern "C"
 {
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
-PaError PulseAudioCloseStreamBlock(PaStream* stream);
-PaError PulseAudioStartStreamBlock(PaStream *stream);
-PaError PulseAudioStopStreamBlock(PaStream *stream);
-PaError PulseAudioAbortStreamBlock(PaStream *stream);
-PaError PulseAudioReadStreamBlock(PaStream* stream, void *buffer, unsigned long frames);
-PaError PulseAudioWriteStreamBlock(PaStream* stream, const void *buffer, unsigned long frames);
-signed long PulseAudioGetStreamReadAvailableBlock(PaStream* stream);
-signed long PulseAudioGetStreamWriteAvailableBlock(PaStream* stream);
+    PaError PulseAudioCloseStreamBlock(
+    PaStream * stream
+    );
+    PaError PulseAudioStartStreamBlock(
+    PaStream * stream
+    );
+    PaError PulseAudioStopStreamBlock(
+    PaStream * stream
+    );
+    PaError PulseAudioAbortStreamBlock(
+    PaStream * stream
+    );
+    PaError PulseAudioReadStreamBlock(
+    PaStream * stream,
+    void *buffer,
+    unsigned long frames
+    );
+    PaError PulseAudioWriteStreamBlock(
+    PaStream * stream,
+    const void *buffer,
+    unsigned long frames
+    );
+    signed long PulseAudioGetStreamReadAvailableBlock(
+    PaStream * stream
+    );
+    signed long PulseAudioGetStreamWriteAvailableBlock(
+    PaStream * stream
+    );
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
 
 #endif
-

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
@@ -1,0 +1,41 @@
+#ifndef _PA_HOSTAPI_PULSEAUDIO_BLOCK_H_
+#define _PA_HOSTAPI_PULSEAUDIO_BLOCK_H_
+
+#include "pa_util.h"
+#include "pa_allocation.h"
+#include "pa_hostapi.h"
+#include "pa_stream.h"
+#include "pa_cpuload.h"
+#include "pa_process.h"
+
+#include "pa_unix_util.h"
+#include "pa_ringbuffer.h"
+
+/* Pulseaudio headers */
+#include <stdio.h>
+#include <string.h>
+#include <pulse/pulseaudio.h>
+
+#include "pa_hostapi_pulseaudio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+PaError PulseaudioCloseStreamBlock(PaStream* stream);
+PaError PulseaudioStartStreamBlock(PaStream *stream);
+PaError PulseaudioStopStreamBlock(PaStream *stream);
+PaError PulseaudioAbortStreamBlock(PaStream *stream);
+PaError PulseaudioReadStreamBlock(PaStream* stream, void *buffer, unsigned long frames);
+PaError PulseaudioWriteStreamBlock(PaStream* stream, const void *buffer, unsigned long frames);
+signed long PulseaudioGetStreamReadAvailableBlock(PaStream* stream);
+signed long PulseaudioGetStreamWriteAvailableBlock(PaStream* stream);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+
+#endif
+

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.h
@@ -11,7 +11,7 @@
 #include "pa_unix_util.h"
 #include "pa_ringbuffer.h"
 
-/* Pulseaudio headers */
+/* PulseAudio headers */
 #include <stdio.h>
 #include <string.h>
 #include <pulse/pulseaudio.h>
@@ -23,14 +23,14 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-PaError PulseaudioCloseStreamBlock(PaStream* stream);
-PaError PulseaudioStartStreamBlock(PaStream *stream);
-PaError PulseaudioStopStreamBlock(PaStream *stream);
-PaError PulseaudioAbortStreamBlock(PaStream *stream);
-PaError PulseaudioReadStreamBlock(PaStream* stream, void *buffer, unsigned long frames);
-PaError PulseaudioWriteStreamBlock(PaStream* stream, const void *buffer, unsigned long frames);
-signed long PulseaudioGetStreamReadAvailableBlock(PaStream* stream);
-signed long PulseaudioGetStreamWriteAvailableBlock(PaStream* stream);
+PaError PulseAudioCloseStreamBlock(PaStream* stream);
+PaError PulseAudioStartStreamBlock(PaStream *stream);
+PaError PulseAudioStopStreamBlock(PaStream *stream);
+PaError PulseAudioAbortStreamBlock(PaStream *stream);
+PaError PulseAudioReadStreamBlock(PaStream* stream, void *buffer, unsigned long frames);
+PaError PulseAudioWriteStreamBlock(PaStream* stream, const void *buffer, unsigned long frames);
+signed long PulseAudioGetStreamReadAvailableBlock(PaStream* stream);
+signed long PulseAudioGetStreamWriteAvailableBlock(PaStream* stream);
 
 #ifdef __cplusplus
 }

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -70,13 +70,6 @@
 #include <string.h>
 #include <pulse/pulseaudio.h>
 
-/* prototypes for functions declared in this file */
-
-#define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
-    PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
-
-
-
 void PulseAudioStreamReadCb(
     pa_stream * s,
     size_t length,

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -1,6 +1,6 @@
 /*
  * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
- * Pulseaudio host to play natively in Linux based systems without
+ * PulseAudio host to play natively in Linux based systems without
  * ALSA emulation
  *
  * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
@@ -42,9 +42,9 @@
 /** @file
  @ingroup common_src
 
- @brief Pulseaudio implementation of support for a host API.
+ @brief PulseAudio implementation of support for a host API.
 
- This host API implements Pulseaudio support for portaudio
+ This host API implements PulseAudio support for portaudio
  it has callbackmode and normal write mode support
 */
 
@@ -64,7 +64,7 @@
 #include "pa_hostapi_pulseaudio_cb.h"
 
 
-/* Pulseaudio headers */
+/* PulseAudio headers */
 #include <stdio.h>
 #include <string.h>
 #include <pulse/pulseaudio.h>
@@ -76,9 +76,9 @@
 
 
 
-void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata)
+void PulseAudioStreamReadCb(pa_stream *s, size_t length, void *userdata)
 {
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream *) userdata;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) userdata;
     PaStreamCallbackTimeInfo timeInfo = {0, 0, 0}; /* TODO: IMPLEMENT ME */
     int l_iResult = paContinue;
     long numFrames = 0;
@@ -152,9 +152,9 @@ void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata)
     pa_threaded_mainloop_signal(l_ptrStream->mainloop, 0);
 }
 
-void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
+void PulseAudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
 {
-    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream *) userdata;
+    PaPulseAudioStream *l_ptrStream = (PaPulseAudioStream *) userdata;
     PaStreamCallbackTimeInfo timeInfo = {0, 0, 0}; /* TODO: IMPLEMENT ME */
     int l_iResult = paContinue;
     long numFrames = 0;
@@ -185,7 +185,7 @@ void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
     else
     {
         PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
-        // fprintf(stderr, "Portaudio [Pulseaudio (PulseaudioStreamWriteCb)]: There is no callback function even PORTAUDIO Callback mode is ON! can write %ld/%ld\n",length,PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing));
+        // fprintf(stderr, "Portaudio [PulseAudio (PulseAudioStreamWriteCb)]: There is no callback function even PORTAUDIO Callback mode is ON! can write %ld/%ld\n",length,PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing));
         long l_iReadCount = l_ptrStream->outputFrameSize * PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing);
 
 
@@ -217,14 +217,14 @@ void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
 
 
 /* This is left for future use! */
-static void PulseaudioStreamSuccessCb(pa_stream *s, int success, void *userdata)
+static void PulseAudioStreamSuccessCb(pa_stream *s, int success, void *userdata)
 {
     PA_DEBUG(("Portaudio %s: %d\n", __FUNCTION__, success));
     assert(s);
 }
 
 /* This is left for future use! */
-void PulseaudioStreamStartedCb(pa_stream *s, void *userdata)
+void PulseAudioStreamStartedCb(pa_stream *s, void *userdata)
 {
     assert(s);
 }
@@ -234,25 +234,25 @@ void PulseaudioStreamStartedCb(pa_stream *s, void *userdata)
     When CloseStream() is called, the multi-api layer ensures that
     the stream has already been stopped or aborted.
 */
-PaError PulseaudioCloseStreamCb(PaStream* s)
+PaError PulseAudioCloseStreamCb(PaStream* s)
 {
     PaError result = paNoError;
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
     pa_operation *l_ptrOperation = NULL;
 
-    pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
 
     if(stream->outStream != NULL)
     {
         /* First we stop (CORK) stream and make sure
          * that we don't write anymore
          */
-        l_ptrOperation = pa_stream_cork(stream->outStream, 1, PulseaudioStreamSuccessCb, NULL);
+        l_ptrOperation = pa_stream_cork(stream->outStream, 1, PulseAudioStreamSuccessCb, NULL);
 
         while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
         }
 
         pa_operation_unref(l_ptrOperation);
@@ -268,7 +268,7 @@ PaError PulseaudioCloseStreamCb(PaStream* s)
 
         while(pa_stream_get_state(stream->outStream) != PA_STREAM_TERMINATED)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
         }
 
         pa_stream_unref(stream->outStream);
@@ -283,11 +283,11 @@ PaError PulseaudioCloseStreamCb(PaStream* s)
         /* First we stop (CORK) stream and make sure
          * that we don't read anymore
          */
-        l_ptrOperation = pa_stream_cork(stream->inStream, 1, PulseaudioStreamSuccessCb, NULL);
+        l_ptrOperation = pa_stream_cork(stream->inStream, 1, PulseAudioStreamSuccessCb, NULL);
 
         while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
         }
 
         pa_operation_unref(l_ptrOperation);
@@ -299,7 +299,7 @@ PaError PulseaudioCloseStreamCb(PaStream* s)
 
         while(pa_stream_get_state(stream->inStream) != PA_STREAM_TERMINATED)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
         }
 
         pa_stream_unref(stream->inStream);
@@ -320,15 +320,15 @@ PaError PulseaudioCloseStreamCb(PaStream* s)
 }
 
 
-PaError PulseaudioStartStreamCb(PaStream *s)
+PaError PulseAudioStartStreamCb(PaStream *s)
 {
     PaError result = paNoError;
-    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseAudioStream *stream = (PaPulseAudioStream*)s;
     int streamStarted = 0;  /* So we can know whether we need to take the stream down */
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
     const char *l_strName = NULL;
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
     /* Ready the processor */
     PaUtil_ResetBufferProcessor(&stream->bufferProcessor);
@@ -349,10 +349,10 @@ PaError PulseaudioStartStreamCb(PaStream *s)
 
         if(stream->device != paNoDevice)
         {
-            PA_DEBUG(("Portaudio %s: %d (%s)\n", __FUNCTION__, stream->device, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device]));
+            PA_DEBUG(("Portaudio %s: %d (%s)\n", __FUNCTION__, stream->device, l_ptrPulseAudioHostApi->pulseaudioDeviceNames[stream->device]));
         }
 
-        pa_stream_connect_playback(stream->outStream, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
+        pa_stream_connect_playback(stream->outStream, l_ptrPulseAudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
                                    PA_STREAM_INTERPOLATE_TIMING
                                    | PA_STREAM_ADJUST_LATENCY
                                    | PA_STREAM_AUTO_TIMING_UPDATE
@@ -361,7 +361,7 @@ PaError PulseaudioStartStreamCb(PaStream *s)
                                    NULL,
                                    NULL);
 
-        pa_stream_set_underflow_callback(stream->outStream, PulseaudioStreamUnderflowCb, stream);
+        pa_stream_set_underflow_callback(stream->outStream, PulseAudioStreamUnderflowCb, stream);
 
         l_strName = NULL;
     }
@@ -375,23 +375,23 @@ PaError PulseaudioStartStreamCb(PaStream *s)
         PA_UNLESS(stream->inBuffer = PaUtil_AllocateMemory(PULSEAUDIO_BUFFER_SIZE),
                   paInsufficientMemory);
 
-        pa_stream_connect_record(stream->inStream, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
+        pa_stream_connect_record(stream->inStream, l_ptrPulseAudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
                                  PA_STREAM_INTERPOLATE_TIMING
                                  | PA_STREAM_ADJUST_LATENCY
                                  | PA_STREAM_AUTO_TIMING_UPDATE
                                  | PA_STREAM_NO_REMIX_CHANNELS
                                  | PA_STREAM_NO_REMAP_CHANNELS);
-        pa_stream_set_underflow_callback(stream->inStream, PulseaudioStreamUnderflowCb, stream);
+        pa_stream_set_underflow_callback(stream->inStream, PulseAudioStreamUnderflowCb, stream);
     }
 
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
     if(stream->outStream != NULL || stream->inStream != NULL)
     {
         while(1)
         {
-            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
-            pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
+            pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
             if(stream->outStream != NULL)
             {
@@ -421,7 +421,7 @@ PaError PulseaudioStartStreamCb(PaStream *s)
                 break;
             }
 
-            pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
             usleep(1000);
         }
@@ -435,7 +435,7 @@ PaError PulseaudioStartStreamCb(PaStream *s)
 
     // Allways unlock.. so we don't get locked
 end:
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
     return result;
 error:
 
@@ -450,17 +450,17 @@ error:
     goto end;
 }
 
-PaError RealStop(PaPulseaudioStream *stream, int abort)
+PaError RealStop(PaPulseAudioStream *stream, int abort)
 {
     PaError result = paNoError;
-    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
 
-    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_lock(l_ptrPulseAudioHostApi->mainloop);
 
     /* Wait for stream to be stopped */
     stream->isActive = 0;
     stream->isStopped = 1;
-    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    pa_threaded_mainloop_unlock(l_ptrPulseAudioHostApi->mainloop);
 
 error:
     stream->isActive = 0;
@@ -469,15 +469,15 @@ error:
     return result;
 }
 
-PaError PulseaudioStopStreamCb(PaStream *s)
+PaError PulseAudioStopStreamCb(PaStream *s)
 {
-    return RealStop((PaPulseaudioStream *)s, 0);
+    return RealStop((PaPulseAudioStream *)s, 0);
 }
 
 
-PaError PulseaudioAbortStreamCb(PaStream *s)
+PaError PulseAudioAbortStreamCb(PaStream *s)
 {
-    return RealStop((PaPulseaudioStream *)s, 1);
+    return RealStop((PaPulseAudioStream *)s, 1);
 }
 
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -272,9 +272,7 @@ PaError PulseAudioCloseStreamCb(
     PaPulseAudioHostApiRepresentation *l_ptrPulseAudioHostApi = stream->hostapi;
     pa_operation *l_ptrOperation = NULL;
 
-    pa_threaded_mainloop_wait(l_ptrPulseAudioHostApi->mainloop);
-
-    if (stream->outStream != NULL)
+    if (stream->outStream != NULL && pa_stream_get_state(stream->outStream) == PA_STREAM_READY)
     {
         /* First we stop (CORK) stream and make sure
          * that we don't write anymore
@@ -311,7 +309,7 @@ PaError PulseAudioCloseStreamCb(
         stream->outBuffer = NULL;
     }
 
-    if (stream->inStream != NULL)
+    if (stream->inStream != NULL && pa_stream_get_state(stream->inStream) == PA_STREAM_READY)
     {
         /* First we stop (CORK) stream and make sure
          * that we don't read anymore

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -1,0 +1,483 @@
+/*
+ * $Id: pa_hostapi_pulseaudio.c 1668 2011-05-02 17:07:11Z rossb $
+ * Pulseaudio host to play natively in Linux based systems without
+ * ALSA emulation
+ *
+ * Copyright (c) 2014 Tuukka Pasanen <tuukka.pasanen@ilmi.fi>
+ *
+ * Based on the Open Source API proposed by Ross Bencina
+ * Copyright (c) 1999-2002 Ross Bencina, Phil Burk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * The text above constitutes the entire PortAudio license; however,
+ * the PortAudio community also makes the following non-binding requests:
+ *
+ * Any person wishing to distribute modifications to the Software is
+ * requested to send the modifications to the original developer so that
+ * they can be incorporated into the canonical version. It is also
+ * requested that these non-binding requests be included along with the
+ * license above.
+ */
+
+/** @file
+ @ingroup common_src
+
+ @brief Pulseaudio implementation of support for a host API.
+
+ This host API implements Pulseaudio support for portaudio
+ it has callbackmode and normal write mode support
+*/
+
+
+#include <string.h> /* strlen() */
+
+#include "pa_util.h"
+#include "pa_allocation.h"
+#include "pa_hostapi.h"
+#include "pa_stream.h"
+#include "pa_cpuload.h"
+#include "pa_process.h"
+
+#include "pa_unix_util.h"
+#include "pa_ringbuffer.h"
+
+#include "pa_hostapi_pulseaudio_cb.h"
+
+
+/* Pulseaudio headers */
+#include <stdio.h>
+#include <string.h>
+#include <pulse/pulseaudio.h>
+
+/* prototypes for functions declared in this file */
+
+#define PA_PULSEAUDIO_SET_LAST_HOST_ERROR(errorCode, errorText) \
+    PaUtil_SetLastHostErrorInfo(paInDevelopment, errorCode, errorText)
+
+
+
+void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata)
+{
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream *) userdata;
+    PaStreamCallbackTimeInfo timeInfo = {0, 0, 0}; /* TODO: IMPLEMENT ME */
+    int l_iResult = paContinue;
+    long numFrames = 0;
+    int i = 0;
+    size_t l_lDataSize = 0;
+    size_t l_lLocation = 0;
+    size_t l_lBufferSize = 0;
+    const void *l_ptrSampleData = NULL;
+
+    assert(s);
+    assert(length > 0);
+
+    if(l_ptrStream == NULL)
+    {
+        PA_DEBUG(("Portaudio %s: Stream is null!\n", __FUNCTION__));
+        return;
+    }
+
+     memset(l_ptrStream->inBuffer, 0x00, PULSEAUDIO_BUFFER_SIZE);
+
+
+        PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
+
+        while (pa_stream_readable_size(s) > 0)
+        {
+            l_ptrSampleData = NULL;
+
+            if(pa_stream_peek(s, &l_ptrSampleData, &l_lDataSize))
+            {
+                PA_DEBUG(("Portaudio %s: Can't read audio!\n", __FUNCTION__));
+                return;
+
+            }
+
+            if (l_lDataSize > 0 &&  l_ptrSampleData)
+            {
+                memcpy(l_ptrStream->inBuffer + l_lBufferSize, l_ptrSampleData, l_lDataSize);
+                l_lBufferSize += l_lDataSize;
+            }
+            else
+            {
+                PA_DEBUG(("Portaudio %s: Can't read!\n", __FUNCTION__));
+            }
+
+
+            pa_stream_drop(s);
+
+        }
+
+    if(l_ptrStream->bufferProcessor.streamCallback != NULL)
+    {
+        PaUtil_BeginBufferProcessing(&l_ptrStream->bufferProcessor, &timeInfo, 0);
+        PaUtil_SetInterleavedInputChannels(&l_ptrStream->bufferProcessor, 0, l_ptrStream->inBuffer, l_ptrStream->inSampleSpec.channels);
+        PaUtil_SetInputFrameCount(&l_ptrStream->bufferProcessor, l_lBufferSize / l_ptrStream->inputFrameSize);
+        numFrames = PaUtil_EndBufferProcessing(&l_ptrStream->bufferProcessor, &l_iResult);
+
+        PaUtil_EndCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer, numFrames);
+    }
+    else
+    {
+        PaUtil_WriteRingBuffer( &l_ptrStream->inputRing, l_ptrStream->inBuffer, l_lBufferSize );
+    }
+
+    if(l_iResult != paContinue)
+    {
+        l_ptrStream->isActive = 0;
+        return;
+    }
+
+
+    pa_threaded_mainloop_signal(l_ptrStream->mainloop, 0);
+}
+
+void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
+{
+    PaPulseaudioStream *l_ptrStream = (PaPulseaudioStream *) userdata;
+    PaStreamCallbackTimeInfo timeInfo = {0, 0, 0}; /* TODO: IMPLEMENT ME */
+    int l_iResult = paContinue;
+    long numFrames = 0;
+    int i = 0;
+
+    assert(s);
+    assert(length > 0);
+
+    if(l_ptrStream == NULL)
+    {
+        PA_DEBUG(("Portaudio %s: Stream is null!\n", __FUNCTION__));
+        return;
+    }
+
+    memset(l_ptrStream->outBuffer, 0x00, PULSEAUDIO_BUFFER_SIZE);
+
+
+    if(l_ptrStream->bufferProcessor.streamCallback != NULL)
+    {
+        PaUtil_BeginBufferProcessing(&l_ptrStream->bufferProcessor, &timeInfo, 0);
+        PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
+
+        PaUtil_SetInterleavedOutputChannels(&l_ptrStream->bufferProcessor, 0, l_ptrStream->outBuffer, l_ptrStream->outSampleSpec.channels);
+        PaUtil_SetOutputFrameCount(&l_ptrStream->bufferProcessor, length / l_ptrStream->outputFrameSize);
+
+        numFrames = PaUtil_EndBufferProcessing(&l_ptrStream->bufferProcessor, &l_iResult);
+    }
+    else
+    {
+        PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
+        // fprintf(stderr, "Portaudio [Pulseaudio (PulseaudioStreamWriteCb)]: There is no callback function even PORTAUDIO Callback mode is ON! can write %ld/%ld\n",length,PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing));
+        long l_iReadCount = l_ptrStream->outputFrameSize * PaUtil_GetRingBufferReadAvailable(&l_ptrStream->outputRing);
+
+
+        if ( l_iReadCount >= (length * l_ptrStream->outputFrameSize))
+        {
+            PaUtil_ReadRingBuffer( &l_ptrStream->outputRing, l_ptrStream->outBuffer, length);
+        } 
+        else if ( l_iReadCount < length && l_iReadCount > 0)
+        {
+            PaUtil_ReadRingBuffer( &l_ptrStream->outputRing, l_ptrStream->outBuffer, l_iReadCount);
+        }
+    }
+
+    if(l_iResult != paContinue)
+    {
+        l_ptrStream->isActive = 0;
+        return;
+    }
+
+    if(pa_stream_write(s, l_ptrStream->outBuffer, length, NULL, 0, PA_SEEK_RELATIVE))
+    {
+        PA_DEBUG(("Portaudio %s: Can't write audio!\n", __FUNCTION__));
+    }
+
+
+    PaUtil_EndCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer, numFrames);
+    pa_threaded_mainloop_signal(l_ptrStream->mainloop, 0);
+}
+
+
+/* This is left for future use! */
+static void PulseaudioStreamSuccessCb(pa_stream *s, int success, void *userdata)
+{
+    PA_DEBUG(("Portaudio %s: %d\n", __FUNCTION__, success));
+    assert(s);
+}
+
+/* This is left for future use! */
+void PulseaudioStreamStartedCb(pa_stream *s, void *userdata)
+{
+    assert(s);
+}
+
+
+/*
+    When CloseStream() is called, the multi-api layer ensures that
+    the stream has already been stopped or aborted.
+*/
+PaError PulseaudioCloseStreamCb(PaStream* s)
+{
+    PaError result = paNoError;
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    pa_operation *l_ptrOperation = NULL;
+
+    pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+
+    if(stream->outStream != NULL)
+    {
+        /* First we stop (CORK) stream and make sure
+         * that we don't write anymore
+         */
+        l_ptrOperation = pa_stream_cork(stream->outStream, 1, PulseaudioStreamSuccessCb, NULL);
+
+        while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
+        {
+            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        }
+
+        pa_operation_unref(l_ptrOperation);
+
+
+        /* Then we cancel all writing (if there is any)
+         *  and wait for disconnetion (TERMINATION) which
+         * can take a while for ethernet connections
+         */
+        pa_stream_cancel_write(stream->outStream);
+        pa_stream_disconnect(stream->outStream);
+
+
+        while(pa_stream_get_state(stream->outStream) != PA_STREAM_TERMINATED)
+        {
+            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        }
+
+        pa_stream_unref(stream->outStream);
+        stream->outStream = NULL;
+
+        PaUtil_FreeMemory(stream->outBuffer);
+        stream->outBuffer = NULL;
+    }
+
+    if(stream->inStream != NULL)
+    {
+        /* First we stop (CORK) stream and make sure
+         * that we don't read anymore
+         */
+        l_ptrOperation = pa_stream_cork(stream->inStream, 1, PulseaudioStreamSuccessCb, NULL);
+
+        while (pa_operation_get_state(l_ptrOperation) == PA_OPERATION_RUNNING)
+        {
+            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        }
+
+        pa_operation_unref(l_ptrOperation);
+
+        /* Then we disconnect stream and wait for
+         * Termination
+         */
+        pa_stream_disconnect(stream->inStream);
+
+        while(pa_stream_get_state(stream->inStream) != PA_STREAM_TERMINATED)
+        {
+            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+        }
+
+        pa_stream_unref(stream->inStream);
+        stream->inStream = NULL;
+
+        PaUtil_FreeMemory(stream->inBuffer);
+        stream->inBuffer = NULL;
+    }
+
+    PaUtil_TerminateBufferProcessor(&stream->bufferProcessor);
+    PaUtil_TerminateStreamRepresentation(&stream->streamRepresentation);
+    PaUtil_FreeMemory(stream);
+
+    stream->isStopped = 1;
+    stream->isActive = 0;
+
+    return result;
+}
+
+
+PaError PulseaudioStartStreamCb(PaStream *s)
+{
+    PaError result = paNoError;
+    PaPulseaudioStream *stream = (PaPulseaudioStream*)s;
+    int streamStarted = 0;  /* So we can know whether we need to take the stream down */
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+    const char *l_strName = NULL;
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+    /* Ready the processor */
+    PaUtil_ResetBufferProcessor(&stream->bufferProcessor);
+
+    stream->latency = 20000;
+    stream->underflows = 0;
+    stream->bufferAttr.fragsize = (uint32_t) - 1;
+    stream->bufferAttr.prebuf = (uint32_t) - 1;
+
+    if(stream->outStream != NULL)
+    {
+        stream->bufferAttr.maxlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+        stream->bufferAttr.minreq = pa_usec_to_bytes(0, &stream->outSampleSpec);
+        stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
+
+        PA_UNLESS(stream->outBuffer = PaUtil_AllocateMemory(PULSEAUDIO_BUFFER_SIZE),
+                   paInsufficientMemory);
+
+        if(stream->device != paNoDevice)
+        {
+            PA_DEBUG(("Portaudio %s: %d (%s)\n", __FUNCTION__, stream->device, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device]));
+        }
+
+        pa_stream_connect_playback(stream->outStream, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
+                                   PA_STREAM_INTERPOLATE_TIMING
+                                   | PA_STREAM_ADJUST_LATENCY
+                                   | PA_STREAM_AUTO_TIMING_UPDATE
+                                   | PA_STREAM_NO_REMIX_CHANNELS
+                                   | PA_STREAM_NO_REMAP_CHANNELS,
+                                   NULL,
+                                   NULL);
+
+        pa_stream_set_underflow_callback(stream->outStream, PulseaudioStreamUnderflowCb, stream);
+
+        l_strName = NULL;
+    }
+
+    if(stream->inStream != NULL)
+    {
+        stream->bufferAttr.maxlength = pa_usec_to_bytes(stream->latency, &stream->inSampleSpec);
+        stream->bufferAttr.minreq = pa_usec_to_bytes(0, &stream->inSampleSpec);
+        stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->inSampleSpec);
+
+        PA_UNLESS(stream->inBuffer = PaUtil_AllocateMemory(PULSEAUDIO_BUFFER_SIZE),
+                   paInsufficientMemory);
+
+        pa_stream_connect_record(stream->inStream, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
+                                 PA_STREAM_INTERPOLATE_TIMING
+                                 | PA_STREAM_ADJUST_LATENCY
+                                 | PA_STREAM_AUTO_TIMING_UPDATE
+                                 | PA_STREAM_NO_REMIX_CHANNELS
+                                 | PA_STREAM_NO_REMAP_CHANNELS);
+        pa_stream_set_underflow_callback(stream->inStream, PulseaudioStreamUnderflowCb, stream);
+    }
+
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+    if(stream->outStream != NULL || stream->inStream != NULL)
+    {
+        while(1)
+        {
+            pa_threaded_mainloop_wait(l_ptrPulseaudioHostApi->mainloop);
+            pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+            if(stream->outStream != NULL)
+            {
+                if(PA_STREAM_READY == pa_stream_get_state(stream->outStream))
+                {
+                    stream->isActive = 1;
+                    stream->isStopped = 0;
+                }
+            }
+
+            else if(stream->inStream != NULL)
+            {
+                if(PA_STREAM_READY == pa_stream_get_state(stream->inStream))
+                {
+                    stream->isActive = 1;
+                    stream->isStopped = 0;
+                }
+            }
+
+            else
+            {
+                break;
+            }
+
+            if(stream->isActive == 1)
+            {
+                break;
+            }
+
+            pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+            usleep(1000);
+        }
+
+    }
+
+    else
+    {
+        goto error;
+    }
+
+    // Allways unlock.. so we don't get locked
+end:
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+    return result;
+error:
+
+    if(streamStarted)
+    {
+        AbortStreamCb(stream);
+    }
+
+    stream->isActive = 0;
+    result = paNotInitialized;
+
+    goto end;
+}
+
+PaError RealStop(PaPulseaudioStream *stream, int abort)
+{
+    PaError result = paNoError;
+    PaPulseaudioHostApiRepresentation *l_ptrPulseaudioHostApi = stream->hostapi;
+
+    pa_threaded_mainloop_lock(l_ptrPulseaudioHostApi->mainloop);
+
+    /* Wait for stream to be stopped */
+    stream->isActive = 0;
+    stream->isStopped = 1;
+    pa_threaded_mainloop_unlock(l_ptrPulseaudioHostApi->mainloop);
+
+error:
+    stream->isActive = 0;
+    stream->isStopped = 1;
+
+    return result;
+}
+
+PaError PulseaudioStopStreamCb(PaStream *s)
+{
+    return RealStop((PaPulseaudioStream *)s, 0);
+}
+
+
+PaError PulseaudioAbortStreamCb(PaStream *s)
+{
+    return RealStop((PaPulseaudioStream *)s, 1);
+}
+
+

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -97,36 +97,36 @@ void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata)
         return;
     }
 
-     memset(l_ptrStream->inBuffer, 0x00, PULSEAUDIO_BUFFER_SIZE);
+    memset(l_ptrStream->inBuffer, 0x00, PULSEAUDIO_BUFFER_SIZE);
 
 
-        PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
+    PaUtil_BeginCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer);
 
-        while (pa_stream_readable_size(s) > 0)
+    while (pa_stream_readable_size(s) > 0)
+    {
+        l_ptrSampleData = NULL;
+
+        if(pa_stream_peek(s, &l_ptrSampleData, &l_lDataSize))
         {
-            l_ptrSampleData = NULL;
-
-            if(pa_stream_peek(s, &l_ptrSampleData, &l_lDataSize))
-            {
-                PA_DEBUG(("Portaudio %s: Can't read audio!\n", __FUNCTION__));
-                return;
-
-            }
-
-            if (l_lDataSize > 0 &&  l_ptrSampleData)
-            {
-                memcpy(l_ptrStream->inBuffer + l_lBufferSize, l_ptrSampleData, l_lDataSize);
-                l_lBufferSize += l_lDataSize;
-            }
-            else
-            {
-                PA_DEBUG(("Portaudio %s: Can't read!\n", __FUNCTION__));
-            }
-
-
-            pa_stream_drop(s);
+            PA_DEBUG(("Portaudio %s: Can't read audio!\n", __FUNCTION__));
+            return;
 
         }
+
+        if (l_lDataSize > 0 &&  l_ptrSampleData)
+        {
+            memcpy(l_ptrStream->inBuffer + l_lBufferSize, l_ptrSampleData, l_lDataSize);
+            l_lBufferSize += l_lDataSize;
+        }
+        else
+        {
+            PA_DEBUG(("Portaudio %s: Can't read!\n", __FUNCTION__));
+        }
+
+
+        pa_stream_drop(s);
+
+    }
 
     if(l_ptrStream->bufferProcessor.streamCallback != NULL)
     {
@@ -192,7 +192,7 @@ void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata)
         if ( l_iReadCount >= (length * l_ptrStream->outputFrameSize))
         {
             PaUtil_ReadRingBuffer( &l_ptrStream->outputRing, l_ptrStream->outBuffer, length);
-        } 
+        }
         else if ( l_iReadCount < length && l_iReadCount > 0)
         {
             PaUtil_ReadRingBuffer( &l_ptrStream->outputRing, l_ptrStream->outBuffer, l_iReadCount);
@@ -345,7 +345,7 @@ PaError PulseaudioStartStreamCb(PaStream *s)
         stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->outSampleSpec);
 
         PA_UNLESS(stream->outBuffer = PaUtil_AllocateMemory(PULSEAUDIO_BUFFER_SIZE),
-                   paInsufficientMemory);
+                  paInsufficientMemory);
 
         if(stream->device != paNoDevice)
         {
@@ -373,7 +373,7 @@ PaError PulseaudioStartStreamCb(PaStream *s)
         stream->bufferAttr.tlength = pa_usec_to_bytes(stream->latency, &stream->inSampleSpec);
 
         PA_UNLESS(stream->inBuffer = PaUtil_AllocateMemory(PULSEAUDIO_BUFFER_SIZE),
-                   paInsufficientMemory);
+                  paInsufficientMemory);
 
         pa_stream_connect_record(stream->inStream, l_ptrPulseaudioHostApi->pulseaudioDeviceNames[stream->device], &stream->bufferAttr,
                                  PA_STREAM_INTERPOLATE_TIMING

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
@@ -23,21 +23,36 @@
 #ifdef __cplusplus
 extern "C"
 {
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
 
-PaError PulseAudioCloseStreamCb(PaStream* stream);
-PaError PulseAudioStartStreamCb(PaStream *stream);
-PaError PulseAudioStopStreamCb(PaStream *stream);
-PaError PulseAudioAbortStreamCb(PaStream *stream);
+    PaError PulseAudioCloseStreamCb(
+    PaStream * stream
+    );
+    PaError PulseAudioStartStreamCb(
+    PaStream * stream
+    );
+    PaError PulseAudioStopStreamCb(
+    PaStream * stream
+    );
+    PaError PulseAudioAbortStreamCb(
+    PaStream * stream
+    );
 
-void PulseAudioStreamReadCb(pa_stream *s, size_t length, void *userdata);
-void PulseAudioStreamWriteCb(pa_stream *s, size_t length, void *userdata);
+    void PulseAudioStreamReadCb(
+    pa_stream * s,
+    size_t length,
+    void *userdata
+    );
+    void PulseAudioStreamWriteCb(
+    pa_stream * s,
+    size_t length,
+    void *userdata
+    );
 
 #ifdef __cplusplus
 }
-#endif /* __cplusplus */
+#endif                          /* __cplusplus */
 
 
 #endif
-

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
@@ -12,7 +12,7 @@
 #include "pa_ringbuffer.h"
 
 
-/* Pulseaudio headers */
+/* PulseAudio headers */
 #include <stdio.h>
 #include <string.h>
 #include <pulse/pulseaudio.h>
@@ -26,13 +26,13 @@ extern "C"
 #endif /* __cplusplus */
 
 
-PaError PulseaudioCloseStreamCb(PaStream* stream);
-PaError PulseaudioStartStreamCb(PaStream *stream);
-PaError PulseaudioStopStreamCb(PaStream *stream);
-PaError PulseaudioAbortStreamCb(PaStream *stream);
+PaError PulseAudioCloseStreamCb(PaStream* stream);
+PaError PulseAudioStartStreamCb(PaStream *stream);
+PaError PulseAudioStopStreamCb(PaStream *stream);
+PaError PulseAudioAbortStreamCb(PaStream *stream);
 
-void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata);
-void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata);
+void PulseAudioStreamReadCb(pa_stream *s, size_t length, void *userdata);
+void PulseAudioStreamWriteCb(pa_stream *s, size_t length, void *userdata);
 
 #ifdef __cplusplus
 }

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.h
@@ -1,0 +1,43 @@
+#ifndef _PA_HOSTAPI_PULSEAUDIO_CB_H_
+#define _PA_HOSTAPI_PULSEAUDIO_CB_H_
+
+#include "pa_util.h"
+#include "pa_allocation.h"
+#include "pa_hostapi.h"
+#include "pa_stream.h"
+#include "pa_cpuload.h"
+#include "pa_process.h"
+
+#include "pa_unix_util.h"
+#include "pa_ringbuffer.h"
+
+
+/* Pulseaudio headers */
+#include <stdio.h>
+#include <string.h>
+#include <pulse/pulseaudio.h>
+
+#include "pa_hostapi_pulseaudio.h"
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+
+PaError PulseaudioCloseStreamCb(PaStream* stream);
+PaError PulseaudioStartStreamCb(PaStream *stream);
+PaError PulseaudioStopStreamCb(PaStream *stream);
+PaError PulseaudioAbortStreamCb(PaStream *stream);
+
+void PulseaudioStreamReadCb(pa_stream *s, size_t length, void *userdata);
+void PulseaudioStreamWriteCb(pa_stream *s, size_t length, void *userdata);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+
+#endif
+

--- a/src/os/unix/pa_unix_hostapis.c
+++ b/src/os/unix/pa_unix_hostapis.c
@@ -43,7 +43,7 @@
 #include "pa_hostapi.h"
 
 PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
-PaError PaPulseaudio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+PaError PaPulseAudio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 /* Added for IRIX, Pieter, oct 2, 2003: */
@@ -98,7 +98,7 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
 #endif
 
 #if PA_USE_PULSEAUDIO
-        PaPulseaudio_Initialize,
+        PaPulseAudio_Initialize,
 #endif
 
 #if PA_USE_SKELETON

--- a/src/os/unix/pa_unix_hostapis.c
+++ b/src/os/unix/pa_unix_hostapis.c
@@ -43,6 +43,7 @@
 #include "pa_hostapi.h"
 
 PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+PaError PaPulseaudio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
 /* Added for IRIX, Pieter, oct 2, 2003: */
@@ -82,7 +83,8 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
 #if PA_USE_JACK
         PaJack_Initialize,
 #endif
-                    /* Added for IRIX, Pieter, oct 2, 2003: */
+
+/* Added for IRIX, Pieter, oct 2, 2003: */
 #if PA_USE_SGI 
         PaSGI_Initialize,
 #endif
@@ -93,6 +95,10 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
 
 #if PA_USE_COREAUDIO
         PaMacCore_Initialize,
+#endif
+
+#if PA_USE_PULSEAUDIO
+        PaPulseaudio_Initialize,
 #endif
 
 #if PA_USE_SKELETON


### PR DESCRIPTION
@illuusio Corking the stream until it fills up a bit sounds like a reasonable idea (looks like the alsa hostapi does something similar), but to fix the glitches I only had to correct the ring buffer logic. 

I'm not entirely comfortable with `pa_threaded_mainloop_lock/unlock/wait/signal` - signal is called from `PulseAudioStreamWriteCb` without explicitly acquiring the lock. This means either:
1. this is unsafe and likely to crash eventually (as noted in the previous PR the lock must be held while calling `pa_threaded_mainloop_signal`)
2. PulseAudio acquires the lock for us before invoking the callback. But surely it wouldn't acquire the _mainloop_ lock when invoking a _stream_ callback? What if something else has the lock already preventing the stream callback from running in time?

For these reasons I replaced it with a semaphore to wake up the thread stuck in `PulseAudioWriteStreamBlock` when the ring buffer fills up. I copied the approach from the JACK host api - see `BlockingWriteStream` in `pa_jack.c` for a description of the algorithm.

There's still work to be done:
1. `ReadStream` presumably needs similar treatment
2. I noticed that even after stopping the blocking-mode stream, `PulseAudioStreamWriteCb` never stops running!
