### PR TITLE
pulseaudio: fix glitches in blocking API

### DIFF
--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -849,6 +849,7 @@ static PaError PulseAudioBlockingInitRingBuffer(
         return paInsufficientMemory;
     }
 
+    sem_init(&stream->outputSem, 0, 0);
     memset(l_ptrBuffer, 0x00, l_lNumBytes);
     return (PaError) PaUtil_InitializeRingBuffer(rbuf, 1, l_lNumBytes,
                                                  l_ptrBuffer);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -849,7 +849,6 @@ static PaError PulseAudioBlockingInitRingBuffer(
         return paInsufficientMemory;
     }
 
-    sem_init(&stream->outputSem, 0, 0);
     memset(l_ptrBuffer, 0x00, l_lNumBytes);
     return (PaError) PaUtil_InitializeRingBuffer(rbuf, 1, l_lNumBytes,
                                                  l_ptrBuffer);

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -18,7 +18,7 @@
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
 
-
+#include <semaphore.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -100,12 +100,14 @@ extern "C"
 
         PaUtilRingBuffer inputRing;
         PaUtilRingBuffer outputRing;
+        sem_t            outputSem;
 
         /* Used in communication between threads */
         volatile sig_atomic_t callback_finished;        /* bool: are we in the "callback finished" state? */
         volatile sig_atomic_t callbackAbort;    /* Drop frames? */
         volatile sig_atomic_t isActive; /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
         volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
+        volatile sig_atomic_t outputFull;       /* is WriteStream blocked waiting for space in the ring buffer? */
 
     }
     PaPulseAudioStream;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.h
@@ -18,8 +18,6 @@
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
 
-#include <semaphore.h>
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -100,14 +98,12 @@ extern "C"
 
         PaUtilRingBuffer inputRing;
         PaUtilRingBuffer outputRing;
-        sem_t            outputSem;
 
         /* Used in communication between threads */
         volatile sig_atomic_t callback_finished;        /* bool: are we in the "callback finished" state? */
         volatile sig_atomic_t callbackAbort;    /* Drop frames? */
         volatile sig_atomic_t isActive; /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
         volatile sig_atomic_t isStopped;        /* Is stream in active state? (Between StartStream and StopStream || !paContinue) */
-        volatile sig_atomic_t outputFull;       /* is WriteStream blocked waiting for space in the ring buffer? */
 
     }
     PaPulseAudioStream;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_block.c
@@ -71,35 +71,17 @@ PaError PulseAudioReadStreamBlock(
     uint8_t *l_ptrData = (uint8_t *) buffer;
     long l_lLength = (frames * l_ptrStream->inputFrameSize);
 
-    pa_threaded_mainloop_lock(l_ptrStream->mainloop);
-
-
-
+    pa_threaded_mainloop_lock( l_ptrStream->mainloop );
     while (l_lLength > 0)
     {
-        if (PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing) >
-            l_lLength)
-        {
-            l_iRet =
-                PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData,
-                                      l_lLength);
-            l_lLength = 0;
-        }
-        else
-        {
-            l_lReadable =
-                PaUtil_GetRingBufferReadAvailable(&l_ptrStream->inputRing);
-            l_iRet =
-                PaUtil_ReadRingBuffer(&l_ptrStream->inputRing, l_ptrData,
-                                      l_lReadable);
-            l_ptrData += l_lReadable;
-            l_lLength -= l_lReadable;
-        }
-
-        pa_threaded_mainloop_wait(l_ptrStream->mainloop);
+        long l_read = PaUtil_ReadRingBuffer( &l_ptrStream->inputRing, l_ptrData,
+                                             l_lLength );
+        l_ptrData += l_read;
+        l_lLength -= l_read;
+        if ( l_lLength > 0 )
+            pa_threaded_mainloop_wait( l_ptrStream->mainloop );
     }
-
-    pa_threaded_mainloop_unlock(l_ptrStream->mainloop);
+    pa_threaded_mainloop_unlock( l_ptrStream->mainloop );
     return paNoError;
 }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -208,17 +208,13 @@ void PulseAudioStreamWriteCb(
                                   l_ptrStream->outBuffer,
                                   length);
         numFrames = numBytes / l_ptrStream->outputFrameSize;
-        if( l_ptrStream->outputFull )
-        {
-            l_ptrStream->outputFull = 0;
-            sem_post(&l_ptrStream->outputSem);
-        }
         if( numBytes < length )
         {
             memset( l_ptrStream->outBuffer + numBytes, 0, length - numBytes );
         }
     }
     PaUtil_EndCpuLoadMeasurement(&l_ptrStream->cpuLoadMeasurer, numFrames);
+    pa_threaded_mainloop_signal( l_ptrStream->mainloop, 0 );
 
     if (l_iResult != paContinue)
     {

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio_cb.c
@@ -146,16 +146,16 @@ void PulseAudioStreamReadCb(
     {
         PaUtil_WriteRingBuffer(&l_ptrStream->inputRing, l_ptrStream->inBuffer,
                                l_lBufferSize);
+        // XXX should check whether all bytes were actually written
     }
+
+    pa_threaded_mainloop_signal(l_ptrStream->mainloop, 0);
 
     if (l_iResult != paContinue)
     {
         l_ptrStream->isActive = 0;
         return;
     }
-
-
-    pa_threaded_mainloop_signal(l_ptrStream->mainloop, 0);
 }
 
 void PulseAudioStreamWriteCb(


### PR DESCRIPTION
@illuusio Corking the stream until it fills up a bit sounds like a reasonable idea (looks like the alsa hostapi does something similar), but to fix the glitches I only had to correct the ring buffer logic. 

I'm not entirely comfortable with `pa_threaded_mainloop_lock/unlock/wait/signal` - signal is called from `PulseAudioStreamWriteCb` without explicitly acquiring the lock. This means either:
1. this is unsafe and likely to crash eventually (as noted in the previous PR the lock must be held while calling `pa_threaded_mainloop_signal`)
2. PulseAudio acquires the lock for us before invoking the callback. But surely it wouldn't acquire the _mainloop_ lock when invoking a _stream_ callback? What if something else has the lock already preventing the stream callback from running in time?

For these reasons I replaced it with a semaphore to wake up the thread stuck in `PulseAudioWriteStreamBlock` when the ring buffer fills up. I copied the approach from the JACK host api - see `BlockingWriteStream` in `pa_jack.c` for a description of the algorithm.

There's still work to be done:
1. `ReadStream` presumably needs similar treatment
2. I noticed that even after stopping the blocking-mode stream, `PulseAudioStreamWriteCb` never stops running!
