### PR TITLE
Add support for non-interleaved audio

### DIFF
--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -945,7 +945,7 @@ static PaError OpenStream(
         stream->inputFrameSize =
             Pa_GetSampleSize(inputSampleFormat) * inputChannelCount;
 
-        result = PulseAudioConvertPortaudioFormatToPulseAudio(inputSampleFormat,
+        result = PulseAudioConvertPortaudioFormatToPulseAudio(hostInputSampleFormat,
                                                               &stream->inSampleSpec);
         if (result != paNoError)
             goto error;
@@ -1038,7 +1038,7 @@ static PaError OpenStream(
         stream->outputFrameSize =
             Pa_GetSampleSize(outputSampleFormat) * outputChannelCount;
 
-        result = PulseAudioConvertPortaudioFormatToPulseAudio(outputSampleFormat,
+        result = PulseAudioConvertPortaudioFormatToPulseAudio(hostOutputSampleFormat,
                                                               &stream->outSampleSpec);
         if (result != paNoError)
             goto error;

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -959,7 +959,7 @@ static PaError OpenStream(
         {
             PA_DEBUG(("Portaudio %s: Invalid input audio spec!\n",
                       __FUNCTION__));
-            result = paUnanticipatedHostError; // should have been caught above
+            result = paUnanticipatedHostError; /* should have been caught above */
             goto error;
         }
 
@@ -1056,7 +1056,7 @@ static PaError OpenStream(
         {
             PA_DEBUG(("Portaudio %s: Invalid audio spec for output!\n",
                       __FUNCTION__));
-            result = paUnanticipatedHostError; // should have been caught above
+            result = paUnanticipatedHostError; /* should have been caught above */
             goto error;
         }
 

--- a/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
+++ b/src/hostapi/pulseaudio/pa_hostapi_pulseaudio.c
@@ -948,7 +948,9 @@ static PaError OpenStream(
         result = PulseAudioConvertPortaudioFormatToPulseAudio(hostInputSampleFormat,
                                                               &stream->inSampleSpec);
         if (result != paNoError)
+        {
             goto error;
+        }
 
         stream->inSampleSpec.rate = sampleRate;
         stream->inSampleSpec.channels = inputChannelCount;
@@ -989,7 +991,9 @@ static PaError OpenStream(
             result = PulseAudioBlockingInitRingBuffer(stream, &stream->inputRing,
                                                       stream->inputFrameSize);
             if (result != paNoError)
+            {
                 goto error;
+            }
         }
 
     }
@@ -1041,7 +1045,9 @@ static PaError OpenStream(
         result = PulseAudioConvertPortaudioFormatToPulseAudio(hostOutputSampleFormat,
                                                               &stream->outSampleSpec);
         if (result != paNoError)
+        {
             goto error;
+        }
 
         stream->outSampleSpec.rate = sampleRate;
         stream->outSampleSpec.channels = outputChannelCount;
@@ -1083,7 +1089,9 @@ static PaError OpenStream(
             result = PulseAudioBlockingInitRingBuffer(stream, &stream->outputRing,
                                                       stream->outputFrameSize);
             if (result != paNoError)
+            {
                 goto error;
+            }
         }
 
         stream->device = outputParameters->device;


### PR DESCRIPTION
Hi Tuukka! Sorry to disappear on you, a lot of things have been demanding my attention (as I guess has also been the case with you). Hope all is well :)

I found this message in `PulseAudioConvertPortaudioFormatToPulseAudio`:

```
    case paNonInterleaved:
        PA_DEBUG(("PulseAudio %s: THIS IS NOT SUPPORTED BY PULSEAUDIO!\n",
```

Which is fine, but actually it doesn't matter if pulse audio supports non-interleaved audio because port audio's buffer processor can adapt it for us (so the user deals with non-interleaved samples but pulse audio sees interleaved samples).

There doesn't seem to be a patest case that uses non-interleaved samples so I modified patest_sine_formats - if curious you can find the modified version on my [patest-sine-non-interleaved](https://github.com/sqweek/portaudio-pulseaudio/commits/patest-sine-non-interleaved) branch.

I also uncovered some problems with the error handling in `OpenStream` - at first my modified test failed like so:

```
Assertion 'm' failed at pulsecore/mutex-posix.c:88, function pa_mutex_lock(). Aborting.
```

Which was `OpenStream` freeing the entire host api representation on failure causing `Terminate` to hit this assertion. The first commit fixes this along with several other error handling problems. After that the test fails like so:

```
An error occured while using the portaudio stream
Error number: -9999
Error message: Unanticipated host error
```

Which is expected since it's only in the second commit that non-interleaved audio support is added. The patch works because `PaUtil_SelectClosestAvailableFormat` discards the `paNonInterleaved` flag - ie. `hostOutputSampleFormat` will never be non-interleaved.
